### PR TITLE
Remove deprecated jinja2 delimiter

### DIFF
--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -27,4 +27,4 @@
 - name: Add packages to versionlock
   shell: yum versionlock {{ item }}
   with_items: { versionlock_items }
-  when: ({{ versionlock_items }} is defined)
+  when: (versionlock_items is defined)


### PR DESCRIPTION
Ansible no longer requires the old style delimiter