### PR TITLE
Add the php-intl extension to the box

### DIFF
--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -19,6 +19,11 @@
     name: php56-php-mysqlnd
     state: latest
 
+- name: instal php-intl
+  yum:
+    name: php56-php-intl
+    state: latest
+
 - name: instal php-bcmath
   yum:
     name: php56-php-bcmath


### PR DESCRIPTION
Several codebases which we set up locally error because of not having the intl php extension available. In order to avoid everyone having to fix this locally this change adds it to the ansible script so the vagrant box will have it.