### PR TITLE
Allow HTTP verbs other than GET/POST

### DIFF
--- a/ansible/roles/nginx/templates/default.conf.j2
+++ b/ansible/roles/nginx/templates/default.conf.j2
@@ -23,7 +23,7 @@ server {
         fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
         fastcgi_param   APPLICATION_ENV    {{ item.application_env | default('development') }};
         fastcgi_read_timeout {{ fastcgi_read_timeout }};
-        dav_methods DELETE GET OPTIONS PATCH POST PUT;
+        dav_methods DELETE PUT;
     }
 
     location ~ /\.ht {

--- a/ansible/roles/nginx/templates/default.conf.j2
+++ b/ansible/roles/nginx/templates/default.conf.j2
@@ -15,14 +15,15 @@ server {
     }
 
     location ~ \.php$ {
-            try_files $uri =404;
-            fastcgi_index index.php;
-            fastcgi_pass  127.0.0.1:9000;
-            include       fastcgi_params;
-            fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
-            fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
-            fastcgi_param   APPLICATION_ENV    {{ item.application_env | default('development') }};
-            fastcgi_read_timeout {{ fastcgi_read_timeout }};
+        try_files $uri =404;
+        fastcgi_index index.php;
+        fastcgi_pass  127.0.0.1:9000;
+        include       fastcgi_params;
+        fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+        fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
+        fastcgi_param   APPLICATION_ENV    {{ item.application_env | default('development') }};
+        fastcgi_read_timeout {{ fastcgi_read_timeout }};
+        dav_methods DELETE GET OPTIONS PATCH POST PUT;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
Currently other HTTP verbs cause a 405 at the nginx level. Nginx is compiled with `--with-http_dav_module` from within the vagrant box so this should be an easy fix