### PR TITLE
Switch from flat centos to the official centos image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
   config.vm.define "default" do |default|
-    default.vm.box = "flat/centos6.5"
+    default.vm.box = "centos/6"
 
     default.vm.network "forwarded_port", guest: 3306, host: 6612
 

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -5,6 +5,7 @@
   roles:
   - check-variables
   - yum
+  - selinux
   - mysql-57
   - memcached
   - php-remove

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -1,0 +1,3 @@
+# Disable SELinux; this is a dev env, and vagrant mounts over nfs, making relabelling difficult
+- selinux:
+    state: disabled

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -34,6 +34,16 @@
     name: yum-plugin-versionlock
     state: present
 
+- name: Install SELinux python bindings
+  yum:
+    name: libselinux-python
+    state: present
+
+- name: Install git
+  yum:
+    name: git
+    state: present
+
 - name: set timezone to Europe/London
   timezone:
     name: Europe/London


### PR DESCRIPTION
This change switches from the 'flat' CentOS 6 image to the official upstream CentOS 6 image, which is managed by the CentOS group upstream (so will get official updates, security patches & etc).

This change also adds support for Vagrant on other hypervisors than VirtualBox: libvirt+qemu-kvm, xhyve, VMware and Hyper-V.

To facilitate this change, and owing to the use of NFS on most platforms, some additional packages are required as well as disabling SELinux (which cannot set contexts on NFS volumes). This is a development environment, and flat/centos6 had SELinux disabled, so this is feature parity.