### PR TITLE
Consolidate packages for speed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
   config.vm.define "default" do |default|
-    default.vm.box = "flat/centos6.5"
+    default.vm.box = "centos/6"
 
     default.vm.network "forwarded_port", guest: 3306, host: 6612
 

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -4,6 +4,7 @@
   become_user: root
   roles:
   - check-variables
+  - core
   - yum
   - selinux
   - mysql-57

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -5,6 +5,7 @@
   roles:
   - check-variables
   - yum
+  - selinux
   - mysql-57
   - memcached
   - php-remove

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -8,8 +8,10 @@
   register: php_binarys
 
 - name: Install PHP Composer
-  shell: "curl -sS https://getcomposer.org/installer | {{ item.path }} && /bin/mv -f /home/vagrant/composer.phar /usr/local/bin/composer creates=/usr/local/bin/composer"
-  with_items: "{{ php_binarys.files }}"
+  get_url:
+    url: https://getcomposer.org/composer.phar
+    dest: /usr/local/bin/composer
+    mode: 0755
 
 - name: Install Global Phing
   become: true

--- a/ansible/roles/core/tasks/main.yml
+++ b/ansible/roles/core/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: set timezone to Europe/London
+  timezone:
+    name: Europe/London

--- a/ansible/roles/memcached/tasks/main.yml
+++ b/ansible/roles/memcached/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install memcached
-  yum:
-    name: memcached
-    state: latest
-
 - name: Add memcached to chkconfig
   command: chkconfig --add memcached
 

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -1,25 +1,4 @@
 ---
-- name: install mysql server
-  yum:
-    name: mysql-community-server
-    state: latest
-  register: mysql_install_packages
-
-- name: install mysql client
-  yum:
-    name: mysql-community-client
-    state: latest
-
-- name: install mysql python
-  yum:
-    name: MySQL-python
-    state: latest
-
-- name: install mysql python connector
-  yum:
-    name: mysql-connector-python
-    state: latest
-
 - name: Create Mysql configuration file
   template: src=my.cnf.j2 dest=/etc/my.cnf
 

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -39,8 +39,7 @@
     dest: ~/.my.cnf
 
 - name: testusers
-  shell: mysql --connect-expired-password -e "SET PASSWORD='#!SomeLongPassword1234'"
-  when: (mysql_install_packages is defined and mysql_install_packages.changed)
+  shell: mysql --connect-expired-password -e "ALTER USER USER() IDENTIFIED BY '#!SomeLongPassword1234'"
 
 - name: update mysql root password for all root accounts
   mysql_user: name={{ mysql_root_db_user }} host={{ item }} password={{ mysql_root_db_pass }} priv='*.*:ALL,GRANT' login_user='root' login_password='#!SomeLongPassword1234'

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -30,7 +30,7 @@
     enabled: true
 
 - name: Temp Root Config
-  shell: cat /var/log/mysqld.log | grep "temporary password" | cut -d ' ' -f 11
+  shell: grep "temporary password" /var/log/mysqld.log | cut -d ' ' -f 11
   register: temporary_mysql_password
 
 - name: Create root MySQL configuration file

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -45,10 +45,6 @@
   mysql_user: name={{ mysql_root_db_user }} host={{ item }} password={{ mysql_root_db_pass }} priv='*.*:ALL,GRANT' login_user='root' login_password='#!SomeLongPassword1234'
   with_items:
    - '%'
-   - 127.0.0.1
-   - ::1
-   - 'localhost.localdomain'
-   - localhost
 
 - name: Create root user MySQL configuration file
   template:

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create Mysql configuration file
+- name: Create MySQL configuration file
   template: src=my.cnf.j2 dest=/etc/my.cnf
 
 - name: Set custom mysqld configuration
@@ -51,13 +51,13 @@
    - 'localhost.localdomain'
    - localhost
 
-- name: Create root user Mysql configuration file
+- name: Create root user MySQL configuration file
   template:
     src: my-root.cnf.j2
     dest: ~/.my.cnf
   notify: restart mysql
 
-- name: Create vagrant user Mysql configuration file
+- name: Create vagrant user MySQL configuration file
   become: true
   become_user: vagrant
   template:

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -33,13 +33,13 @@
   shell: cat /var/log/mysqld.log | grep "temporary password" | cut -d ' ' -f 11
   register: temporary_mysql_password
 
-- name: Create root Mysql configuration file
+- name: Create root MySQL configuration file
   template:
     src: my-default-root.cnf.j2
     dest: ~/.my.cnf
 
 - name: testusers
-  shell: mysql --connect-expired-password -e "ALTER USER USER() IDENTIFIED BY '#!SomeLongPassword1234'"
+  shell: mysql --connect-expired-password -e "SET PASSWORD='#!SomeLongPassword1234'"
   when: (mysql_install_packages is defined and mysql_install_packages.changed)
 
 - name: update mysql root password for all root accounts

--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -52,6 +52,9 @@
     dest: ~/.my.cnf
   notify: restart mysql
 
+- name: Make the input settings less likely to destroy a whole SQL query
+  template: src=editrc dest=~/.editrc
+
 - name: Create vagrant user MySQL configuration file
   become: true
   become_user: vagrant

--- a/ansible/roles/mysql-57/templates/editrc
+++ b/ansible/roles/mysql-57/templates/editrc
@@ -1,0 +1,2 @@
+bind "^W" ed-delete-prev-word
+bind "^U" vi-kill-line-prev

--- a/ansible/roles/mysql-57/templates/my-default-root.cnf.j2
+++ b/ansible/roles/mysql-57/templates/my-default-root.cnf.j2
@@ -1,3 +1,3 @@
 [client]
 user=root
-password={{ temporary_mysql_password.stdout }}
+password='{{ temporary_mysql_password.stdout }}'

--- a/ansible/roles/mysql-57/templates/my-root.cnf.j2
+++ b/ansible/roles/mysql-57/templates/my-root.cnf.j2
@@ -1,3 +1,4 @@
 [client]
 user={{ mysql_root_db_user }}
 password='{{ mysql_root_db_pass }}'
+prompt='(\u@\h) [\d]> '

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install Nginx
-  yum:
-    name: nginx
-    state: latest
-
 - name: Add nginx to chkconfig
   command: chkconfig --add nginx
 

--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -1,63 +1,29 @@
 ---
-- name: install php
+- name: install php 5.6
   yum:
-    name: php56
+    name: "{{ packages }}"
     state: latest
     enablerepo: remi,remi-php56
+  vars:
+    packages:
+    - php56
+    - php56-php-mbstring
+    - php56-php-pdo
+    - php56-php-mysqlnd
+    - php56-php-intl
+    - php56-php-bcmath
+    - php56-php-soap
+    - php56-php-pecl-xdebug
+    - php56-php-pecl-memcache
+    - php56-php-pecl-memcached
+    - php56-php-mcrypt
+    - php56-php-fpm
 
-- name: install php-mbstring
-  yum:
-    name: php56-php-mbstring
-
-- name: install php-mcrypt
-  yum:
-    name: php56-php-mcrypt
-
-- name: install php-pdo
-  yum:
-    name: php56-php-pdo
-    state: latest
-
-- name: install php-mysqlnd
-  yum:
-    name: php56-php-mysqlnd
-    state: latest
-
-- name: install php-intl
-  yum:
-    name: php56-php-intl
-    state: latest
-
-- name: install php-bcmath
-  yum:
-    name: php56-php-bcmath
-    state: latest
-
-- name: install php-soap
-  yum:
-    name: php56-php-soap
-    state: latest
-
-- name: install php-xdebug
-  yum:
-    name: php56-php-pecl-xdebug
-    state: latest
-
-- name: install php-memcache
-  yum:
-    name: php56-php-pecl-memcache
-    state: latest
-
-- name: install php-memcached
-  yum:
-    name: php56-php-pecl-memcached
-    state: latest
-
-- name: install php-fpm
-  yum:
-    name: php56-php-fpm
-    state: latest
-    enablerepo: remi,remi-php56
+- name: set access log file
+  file:
+    state: directory
+    path: /var/log/php-fpm
+    mode: 0777
 
 - name: php.ini file
   template:
@@ -73,12 +39,6 @@
   file:
     state: directory
     path: /var/lib/php/session
-    mode: 0777
-
-- name: set access log file
-  file:
-    state: directory
-    path: /var/log/php-fpm
     mode: 0777
 
 - name: set access log file

--- a/ansible/roles/php-72/tasks/main.yml
+++ b/ansible/roles/php-72/tasks/main.yml
@@ -1,69 +1,24 @@
 ---
-- name: install php
+- name: install php 7.2
   yum:
-    name: php72
+    name: "{{ packages }}"
     state: latest
     enablerepo: remi,remi-php72
-
-- name: install php-mbstring
-  yum:
-    name: php72-php-mbstring
-
-- name: install php-pdo
-  yum:
-    name: php72-php-pdo
-    state: latest
-
-- name: install php-mysqlnd
-  yum:
-    name: php72-php-mysqlnd
-    state: latest
-
-- name: install php-intl
-  yum:
-    name: php72-php-intl
-    state: latest
-
-- name: install php-bcmath
-  yum:
-    name: php72-php-bcmath
-    state: latest
-
-- name: install php-soap
-  yum:
-    name: php72-php-soap
-    state: latest
-
-- name: install php-xdebug
-  yum:
-    name: php72-php-pecl-xdebug
-    state: latest
-
-- name: install php-xml
-  yum:
-    name: php72-php-xml
-    state: latest
-
-- name: install php-zip
-  yum:
-    name: php72-php-zip
-    state: latest
-
-- name: install php-memcache
-  yum:
-    name: php72-php-pecl-memcache
-    state: latest
-
-- name: install php-memcached
-  yum:
-    name: php72-php-pecl-memcached
-    state: latest
-
-- name: install php-fpm
-  yum:
-    name: php72-php-fpm
-    state: latest
-    enablerepo: remi,remi-php72
+  vars:
+    packages:
+    - php72
+    - php72-php-mbstring
+    - php72-php-pdo
+    - php72-php-mysqlnd
+    - php72-php-intl
+    - php72-php-bcmath
+    - php72-php-soap
+    - php72-php-pecl-xdebug
+    - php72-php-xml
+    - php72-php-zip
+    - php72-php-pecl-memcache
+    - php72-php-pecl-memcached
+    - php72-php-fpm
 
 - name: set access log file
   file:

--- a/ansible/roles/php-73/tasks/main.yml
+++ b/ansible/roles/php-73/tasks/main.yml
@@ -1,69 +1,24 @@
 ---
-- name: instal php
+- name: install php 7.3
   yum:
-    name: php73
+    name: "{{ packages }}"
     state: latest
     enablerepo: remi,remi-php73
-
-- name: instal php-mbstring
-  yum:
-    name: php73-php-mbstring
-
-- name: instal php-pdo
-  yum:
-    name: php73-php-pdo
-    state: latest
-
-- name: instal php-mysqlnd
-  yum:
-    name: php73-php-mysqlnd
-    state: latest
-
-- name: instal php-intl
-  yum:
-    name: php73-php-intl
-    state: latest
-
-- name: instal php-bcmath
-  yum:
-    name: php73-php-bcmath
-    state: latest
-
-- name: instal php-soap
-  yum:
-    name: php73-php-soap
-    state: latest
-
-- name: instal php-xdebug
-  yum:
-    name: php73-php-pecl-xdebug
-    state: latest
-
-- name: instal php-xml
-  yum:
-    name: php73-php-xml
-    state: latest
-
-- name: install php-zip
-  yum:
-    name: php73-php-zip
-    state: latest
-
-- name: instal php-memcache
-  yum:
-    name: php73-php-pecl-memcache
-    state: latest
-
-- name: instal php-memcached
-  yum:
-    name: php73-php-pecl-memcached
-    state: latest
-
-- name: instal php-fpm
-  yum:
-    name: php73-php-fpm
-    state: latest
-    enablerepo: remi,remi-php73
+  vars:
+    packages:
+    - php73
+    - php73-php-mbstring
+    - php73-php-pdo
+    - php73-php-mysqlnd
+    - php73-php-intl
+    - php73-php-bcmath
+    - php73-php-soap
+    - php73-php-pecl-xdebug
+    - php73-php-xml
+    - php73-php-zip
+    - php73-php-pecl-memcache
+    - php73-php-pecl-memcached
+    - php73-php-fpm
 
 - name: set access log file
   file:

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -1,0 +1,3 @@
+# Disable SELinux; this is a dev env, and vagrant mounts over nfs, making relabelling difficult
+- selinux:
+    state: disabled

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -34,6 +34,16 @@
     name: yum-plugin-versionlock
     state: present
 
+- name: Install SELinux python bindings
+  yum:
+    name: libselinux-python
+    state: present
+
+- name: Install git
+  yum:
+    name: git
+    state: present
+
 - name: set timezone to Europe/London
   timezone:
     name: Europe/London

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -29,6 +29,10 @@
     - yum-plugin-versionlock
     - libselinux-python
     - git
+    - mysql-community-server
+    - mysql-community-client
+    - MySQL-python
+    - mysql-connector-python
 
 - name: Lock packages to required versions
   shell: yum versionlock {{ item }}

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -34,6 +34,7 @@
     - MySQL-python
     - mysql-connector-python
     - memcached
+    - nginx
 
 - name: Lock packages to required versions
   shell: yum versionlock {{ item }}

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -4,51 +4,33 @@
     name: epel-release
     state: latest
 
-- name: install the remi rpm from a remote repo
+- name: setup third party repositories (remi, mysql-community)
   yum:
-    name: http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+    name: "{{ packages }}"
     state: present
-
-- name: install the mysql 5.7 rpm from a remote repo
-  yum:
-    name: http://repo.mysql.com/mysql57-community-release-el6.rpm
-    state: present
-
+  vars:
+    packages:
+    - http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+    - http://repo.mysql.com/mysql57-community-release-el6.rpm
+  
 - name: add epel public key
   rpm_key:
     state: present
     key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 
-- name: Update NSS (needed for github tls1.3)
+- name: update/install required packages
   yum:
-    name: nss
+    name: "{{ packages }}"
     state: latest
+  vars:
+    packages:
+    - nss
+    - nc
+    - yum-plugin-versionlock
+    - libselinux-python
+    - git
 
-- name: Install NC (NetCat)
-  yum:
-    name: nc
-    state: latest
-
-- name: Install yum-versionlock
-  yum:
-    name: yum-plugin-versionlock
-    state: present
-
-- name: Install SELinux python bindings
-  yum:
-    name: libselinux-python
-    state: present
-
-- name: Install git
-  yum:
-    name: git
-    state: present
-
-- name: set timezone to Europe/London
-  timezone:
-    name: Europe/London
-
-- name: Add packages to versionlock
+- name: Lock packages to required versions
   shell: yum versionlock {{ item }}
   with_items: { versionlock_items }
   when: (versionlock_items is defined)

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -33,6 +33,7 @@
     - mysql-community-client
     - MySQL-python
     - mysql-connector-python
+    - memcached
 
 - name: Lock packages to required versions
   shell: yum versionlock {{ item }}


### PR DESCRIPTION
This change does a number of things under the umbrella of improving provisioning speed & reducing output clutter:
* Consolidate yum transactions to two transactions (one for most packages, one for php) - considerably speeding up provisioning speed
* Move the timezone setting to the `core` role
* Simplify creating MySQL user accounts by using `%` and not creating per-host acounts
* Add an informational MySQL prompt, restore ctrl-w/ctrl-u behaviour to that of the Red Hat MySQL packages
* In situations where a hash occurs in the temporary password, inserting that password into the `.my.cnf` file results in the marker being considered as a comment marker; that's fixed now, so provisioning works more of the time
* Use `get_url` rather than shelling `curl`, because ansible complains about this (also means proxy rules that are setup for ansible are adhered to)

This requires my earlier PR to be applied (moving to official CentOS 6 image away from flat/centos6) prior to application.