### PR TITLE
Xdebug Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,22 @@ vagrant up
 ```
 
 ### Add Virtual Hosts
-Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all` file. Set the `host_name` to the virtual host that you would like to use.
+Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all` file. Set the `host_name` to the 
+virtual host that you would like to use.
 
-Add the following line `192.168.33.35 {host_name}` (where the `{host_name}` is the one from the `all` file) to your hosts file `/etc/hosts`
+Add the following line `192.168.33.35 {host_name}` (where the `{host_name}` is the one from the `all` file) to your 
+hosts file `/etc/hosts` on your host machine.
 
 ### Change PHP Versions
 Edit `ansible/group_vars/all` with your favourite editor and change
-the `php_version` variable. 5.6 and 7.2 are the only allowed version numbers at this time.
+the `php_version` variable. 5.6, 7.2 and 7.3 are the only allowed version numbers at this time.
 
-### Update Dependencies
-After changing any ansible settings just run `vagrant up --provision` to propagate the changes to the VM.
+### Provision with Xdebug enabled
+Edit `ansible/group_vars/all` with your favourite editor and change
+the `xdebug` variable from false (default) to true.
+
+### Update Dependencies / Reprovision
+**After changing any ansible settings you must run `vagrant up --provision` to propagate the changes to the VM**.
 
 ### Requirements
 - **git**
@@ -43,22 +49,41 @@ After changing any ansible settings just run `vagrant up --provision` to propaga
 
   Install Ansible, instructions can be found here: [Ansible](http://docs.ansible.com/ansible/intro_installation.html#installing-the-control-machine)
 
-### Config File Location Inside The Virtual Machine
+### Virtual machine config files and CLI commands
 **Nginx**
-- error log setting : `/var/log/php-fpm/error.log`
+- php error log setting : `/var/log/php-fpm/error.log`
 - nginx configuration : `/etc/nginx/nginx.conf`
-
-**PHP**
-- php.ini file is at : `/opt/remi/php56/root/etc/php.ini`
-- Xdebug executable : `/opt/remi/php56/root/usr/lib64/php/modules/xdebug.so`
-- xdebug.ini file at : `/opt/remi/php56/root/etc/php.d/15-xdebug.ini`
-
-**CentOS**
 - restart nginx : `sudo service nginx restart`
-- to restart PHP-FPM : `sudo service php56-php-fpm restart`
 
-### Running multiple machines
-- Duplicate the `"default"` block in `Vagrantfile`
-- Rename `"default"` to something else (e.g. `"newVm"`)
-- Change both the host port (from `6612`) and the ip (from `192.168.33.35`)
-- Access new vm using `vagrant up newVm` and `vagrant ssh newVm`
+**PHP 5.6**
+- php.ini file is at : `/opt/remi/php56/root/etc/php.ini`
+- additional ini files scan directory at : `/opt/remi/php56/root/etc/php.d/`
+- to restart php : `sudo service php56-php-fpm restart`
+
+**PHP 7.2**
+- php.ini file is at : `/etc/opt/remi/php72/php.ini`
+- additional ini files scan directory at : `/etc/opt/remi/php72/php.d/`
+- to restart php : `sudo service php72-php-fpm restart`
+
+**PHP 7.3**
+- php.ini file is at : `/etc/opt/remi/php73/php.ini`
+- additional ini files scan directory at : `/etc/opt/remi/php73/php.d/`
+- to restart php : `sudo service php73-php-fpm restart`
+
+### Running multiple applications and virtual machines
+- To run two separate virtual machines from two separate copies of the vagrant-ansible-centos6-LNMP codebase you will 
+need to adjust the port and ip settings in the second `Vagrantfile` to avoid clashes with your first virtual machine. 
+For example change port 6612 and ip 192.168.33.35 to:
+ ```
+default.vm.network "forwarded_port", guest: 3306, host: 6613
+default.vm.network :private_network, ip: "192.168.33.36"
+```
+You will also need to amend the entry in `ansible/hosts` file to match the changed ip address. When creating virtual 
+hosts in accordance with the "Add Virtual Hosts" instructions above use the changed ip address in /etc/hosts entries.
+- To run multiple virtual machines from a single copy of the vagrant-ansible-centos6-LNMP codebase from a single 
+Vagrant file you will need to:
+    - Duplicate the `"default"` block in `Vagrantfile`
+    - Rename `"default"` to something else (e.g. `"newVm"`)
+    - Change both the host port (from `6612`) and the ip (from `192.168.33.35`) to avoid clashes (see above)
+    - Change entry in `ansible/hosts` to match new name and ip
+    - Access new vm using `vagrant up newVm` and `vagrant ssh newVm`

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ Edit `ansible/group_vars/all` with your favourite editor and change
 the `php_version` variable. 5.6, 7.2 and 7.3 are the only allowed version numbers at this time.
 
 ### Provision with Xdebug enabled
-Edit `ansible/group_vars/all` with your favourite editor and change
-the `xdebug` variable from false (default) to true.
+Edit `ansible/group_vars/all` with your favourite editor and change the `xdebug` variable from 
+false (default) to true. Add appropriate value to `xdebug_ide_key` variable e.g. "PHPSTORM".
+You will then need to set up your IDE to listen to incoming Xdebug connections on port 9001 (default is 9000 but clashes
+with PHP-FPM). When xdebug is true bash aliases are made available for setting and unsetting environment variables 
+to aid command line debugging - see 'xdebugstart' and 'xdebugstop' in ~/.bashrc.
 
 ### Update Dependencies / Reprovision
 **After changing any ansible settings you must run `vagrant up --provision` to propagate the changes to the VM**.

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -35,8 +35,10 @@ fastcgi_read_timeout: 60
 # PHP Version
 php_version: "7.2"
 
-# Xdebug Setting
-xdebug: False
+# Xdebug Setting - set to true for enabled xdebug.ini settings and cli environment variables commands
+# set appropriate value for xdebug_ide_key e.g. "PHPSTORM"
+xdebug: false
+xdebug_ide_key: "EXAMPLEIDE"
 
 # NginX Virtual Hosts
 virtual_hosts:

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -29,7 +29,10 @@ node_version: stable
 fastcgi_read_timeout: 60
 
 # PHP Version
-php_version: "5.6"
+php_version: "7.2"
+
+# Xdebug Setting
+xdebug: False
 
 # NginX Virtual Hosts
 virtual_hosts:

--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -64,6 +64,12 @@
     src: php.ini
     dest: /opt/remi/php56/root/etc/php.ini
 
+- name: xdebug.ini file
+  template:
+    src: xdebug.ini
+    dest: /opt/remi/php56/root/etc/php.d/15-xdebug.ini
+  when: xdebug | default(False) is True
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -34,7 +34,7 @@
   template:
     src: xdebug.ini
     dest: /opt/remi/php56/root/etc/php.d/15-xdebug.ini
-  when: xdebug | default(False) is True
+  when: xdebug|d(False) == True
 
 - name: www.cnf file
   template:

--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -36,6 +36,16 @@
     dest: /opt/remi/php56/root/etc/php.d/15-xdebug.ini
   when: xdebug|d(False) == True
 
+- name: edit xdebug.idekey value
+  lineinfile:
+    path: /opt/remi/php56/root/etc/php.d/15-xdebug.ini
+    regexp: '^;xdebug\.idekey = \*complex\*'
+    line: 'xdebug.idekey = {{ xdebug_ide_key }}'
+    state: present
+  when:
+    - xdebug|d(False) == True
+    - xdebug_ide_key is defined
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-56/templates/xdebug.ini
+++ b/ansible/roles/php-56/templates/xdebug.ini
@@ -1,0 +1,1021 @@
+; Enable xdebug extension module
+zend_extension=xdebug.so
+
+
+; -----------------------------------------------------------------------------
+; xdebug.auto_trace
+;
+; Type: boolean, Default value: 0
+;
+; When this setting is set to on, the tracing of function calls will be enabled
+; just before the script is run. This makes it possible to trace code in the
+; auto_prepend_file [1].
+;
+; [1] http://php.net/manual/en/ini.core.php#ini.auto-prepend-file
+;
+;
+;xdebug.auto_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.cli_color
+;
+; Only in Xdebug versions > 2.2
+;
+; Type: integer, Default value: 0
+;
+; If this setting is 1, Xdebug will color var_dumps and stack traces output when
+; in CLI mode and when the output is a tty. On Windows, the ANSICON [1] tool
+; needs to be installed.
+;
+; [1] http://adoxa.110mb.com/ansicon/
+;
+; If the setting is 2, then Xdebug will always color var_dumps and stack trace,
+; no matter whether it's connected to a tty or whether ANSICON is installed. In
+; this case, you might end up seeing escape codes.
+;
+; See this article [1] for some more information.
+;
+; [1] http://drck.me/clicolor-9cr
+;
+;
+;xdebug.cli_color = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_assignments
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should add variable
+; assignments to function traces.
+;
+;
+;xdebug.collect_assignments = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_includes
+;
+; Type: boolean, Default value: 1
+;
+; This setting, defaulting to 1, controls whether Xdebug should write the
+; filename used in include(), include_once(), require() or require_once() to the
+; trace files.
+;
+;
+;xdebug.collect_includes = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_params
+;
+; Type: integer, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should collect the
+; parameters passed to functions when a function call is recorded in either the
+; function trace or the stack trace.
+;
+; The setting defaults to 0 because for very large scripts it may use huge
+; amounts of memory and therefore make it impossible for the huge script to run.
+; You can most safely turn this setting on, but you can expect some problems in
+; scripts with a lot of function calls and/or huge data structures as
+; parameters. Xdebug 2 will not have this problem with increased memory usage,
+; as it will never store this information in memory. Instead it will only be
+; written to disk. This means that you need to have a look at the disk usage
+; though.
+;
+; This setting can have four different values. For each of the values a
+; different amount of information is shown. Below you will see what information
+; each of the values provides. See also the introduction of the feature Stack
+; Traces for a few screenshots.
+;
+; =====  ========================================================================
+; Value  Argument Information Shown
+; =====  ========================================================================
+; 0      None.
+; -----  ------------------------------------------------------------------------
+; 1      Type and number of elements (f.e. string(6), array(8)).
+; -----  ------------------------------------------------------------------------
+; 2      Type and number of elements, with a tool tip for the full information 1.
+; -----  ------------------------------------------------------------------------
+; 3      Full variable contents (with the limits respected as set by
+;        xdebug.var_display_max_children, xdebug.var_display_max_data and
+;        xdebug.var_display_max_depth.
+; -----  ------------------------------------------------------------------------
+; 4      Full variable contents and variable name.
+; -----  ------------------------------------------------------------------------
+; 5      PHP serialized variable contents, without the name.
+;
+;        (New in Xdebug 2.3)
+; =====  ========================================================================
+;
+; 1 in the CLI version of PHP it will not have the tool tip, nor in output
+; files.
+;
+;
+;xdebug.collect_params = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_return
+;
+; Type: boolean, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should write the return
+; value of function calls to the trace files.
+;
+; For computerized trace files (xdebug.trace_format=1) this only works from
+; Xdebug 2.3 onwards.
+;
+;
+;xdebug.collect_return = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_vars
+;
+; Type: boolean, Default value: 0
+;
+; This setting tells Xdebug to gather information about which variables are used
+; in a certain scope. This analysis can be quite slow as Xdebug has to reverse
+; engineer PHP's opcode arrays. This setting will not record which values the
+; different variables have, for that use xdebug.collect_params. This setting
+; needs to be enabled only if you wish to use xdebug_get_declared_vars().
+;
+;
+;xdebug.collect_vars = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.coverage_enable
+;
+; Only in Xdebug versions >= 2.2
+;
+; Type: boolean, Default value: 1
+;
+; If this setting is set to 0, then Xdebug will not set-up internal structures
+; to allow code coverage. This speeds up Xdebug quite a bit, but of course, Code
+; Coverage Analysis won't work.
+;
+;
+;xdebug.coverage_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.default_enable
+;
+; Type: boolean, Default value: 1
+;
+; If this setting is 1, then stacktraces will be shown by default on an error
+; event. You can disable showing stacktraces from your code with
+; xdebug_disable(). As this is one of the basic functions of Xdebug, it is
+; advisable to leave this setting set to 1.
+;
+;
+;xdebug.default_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump.*
+;
+; Type: string, Default value: Empty
+;
+; * can be any of COOKIE, FILES, GET, POST, REQUEST, SERVER, SESSION. These
+; seven settings control which data from the superglobals is shown when an error
+; situation occurs.
+;
+; Each of those php.ini setting can consist of a comma seperated list of
+; variables from this superglobal to dump, or ``*`` for all of them. Make sure
+; you do not add spaces in this setting.
+;
+; In order to dump the REMOTE_ADDR and the REQUEST_METHOD when an error occurs,
+; and all GET parameters, add these settings:
+;
+;     xdebug.dump.SERVER = REMOTE_ADDR,REQUEST_METHOD
+;     xdebug.dump.GET = *
+;
+;
+;xdebug.dump.* = Empty
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_globals
+;
+; Type: boolean, Default value: 1
+;
+; Controls whether the values of the superglobals as defined by the
+; xdebug.dump.* settings should be shown or not.
+;
+;
+;xdebug.dump_globals = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_once
+;
+; Type: boolean, Default value: 1
+;
+; Controls whether the values of the superglobals should be dumped on all error
+; situations (set to 0) or only on the first (set to 1).
+;
+;
+;xdebug.dump_once = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_undefined
+;
+; Type: boolean, Default value: 0
+;
+; If you want to dump undefined values from the superglobals you should set this
+; setting to 1, otherwise leave it set to 0.
+;
+;
+;xdebug.dump_undefined = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.extended_info
+;
+; Type: integer, Default value: 1
+;
+; Controls whether Xdebug should enforce 'extended_info' mode for the PHP
+; parser; this allows Xdebug to do file/line breakpoints with the remote
+; debugger. When tracing or profiling scripts you generally want to turn off
+; this option as PHP's generated oparrays will increase with about a third of
+; the size slowing down your scripts. This setting can not be set in your
+; scripts with ini_set(), but only in php.ini.
+;
+;
+;xdebug.extended_info = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.file_link_format
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: string, Default value:
+;
+; This setting determines the format of the links that are made in the display
+; of stack traces where file names are used. This allows IDEs to set up a
+; link-protocol that makes it possible to go directly to a line and file by
+; clicking on the filenames that Xdebug shows in stack traces. An example format
+; might look like:
+;
+;     myide://%f@%l
+;
+; The possible format specifiers are:
+;
+; =========  ===============
+; Specifier  Meaning
+; =========  ===============
+; %f         the filename
+; ---------  ---------------
+; %l         the line number
+; =========  ===============
+;
+; For various IDEs/OSses there are some instructions listed on how to make this
+; work:
+;
+; ----------------
+; Firefox on Linux
+; ----------------
+;
+; - Open
+;
+;   about:config
+;
+; - Add a new boolean setting "network.protocol-handler.expose.xdebug" and set
+;   it to "false"
+;
+; - Add the following into a shell script
+;
+;   ``~/bin/ff-xdebug.sh``:
+;
+;     #! /bin/sh
+;
+;     f=`echo $1 | cut -d @ -f 1 | sed 's/xdebug:\/\///'`
+;     l=`echo $1 | cut -d @ -f 2`
+;
+;   Add to that one of (depending whether you have komodo, gvim or netbeans):
+;
+;   - komodo $f -l $l
+;
+;   - gvim --remote-tab +$l $f
+;
+;   - netbeans "$f:$l"
+;
+; - Make the script executable with
+;
+; chmod +x ~/bin/ff-xdebug.sh
+;
+; - Set the xdebug.file_link_format setting to
+;
+; xdebug://%f@%l
+;
+; --------------------
+; Windows and netbeans
+; --------------------
+;
+; - Create the file
+;
+;   ``netbeans.bat`` and save it in your path ( ``C:\Windows`` will work):
+;
+;     @echo off
+;     setlocal enableextensions enabledelayedexpansion
+;     set NETBEANS=%1
+;     set FILE=%~2
+;     %NETBEANS% --nosplash --console suppress --open "%FILE:~19%"
+;     nircmd win activate process netbeans.exe
+;
+;   **Note:** Remove the last line if you don't have ``nircmd``.
+;
+; - Save the following code as
+;
+;   ``netbeans_protocol.reg``:
+;
+;     Windows Registry Editor Version 5.00
+;
+;     [HKEY_CLASSES_ROOT\netbeans]
+;     "URL Protocol"=""
+;     @="URL:Netbeans Protocol"
+;
+;     [HKEY_CLASSES_ROOT\netbeans\DefaultIcon]
+;     @="\"C:\\Program Files\\NetBeans 7.1.1\\bin\\netbeans.exe,1\""
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell]
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell\open]
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell\open\command]
+;     @="\"C:\\Windows\\netbeans.bat\" \"C:\\Program Files\\NetBeans 7.1.1\\bin\\netbeans.exe\" \"%1\""
+;
+;   **Note:** Make sure to change the path to Netbeans (twice), as well as the
+;   ``netbeans.bat`` batch file if you saved it somewhere else than
+;   ``C:\Windows\``.
+;
+; - Double click on the
+;
+;   ``netbeans_protocol.reg`` file to import it into the registry.
+;
+; - Set the xdebug.file_link_format setting to
+;
+; xdebug.file_link_format =
+;     "netbeans://open/?f=%f:%l"
+;
+;
+;xdebug.file_link_format =
+
+; -----------------------------------------------------------------------------
+; xdebug.force_display_errors
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; If this setting is set to ``1`` then errors will **always** be displayed, no
+; matter what the setting of PHP's display_errors [1] is.
+;
+; [1] http://php.net/manual/en/errorfunc.configuration.php#ini.display-errors
+;
+;
+;xdebug.force_display_errors = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.force_error_reporting
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; This setting is a bitmask, like error_reporting [1]. This bitmask will be
+; logically ORed with the bitmask represented by error_reporting [2] to dermine
+; which errors should be displayed. This setting can only be made in php.ini and
+; allows you to force certain errors from being shown no matter what an
+; application does with ini_set() [3].
+;
+; [1] http://php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+; [2] http://php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+; [3] http://php.net/manual/en/function.ini-set.php
+;
+;
+;xdebug.force_error_reporting = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.halt_level
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; This setting allows you to configure a mask that determines whether, and
+; which, notices and/or warnings get converted to errors. You can configure
+; notices and warnings that are generated by PHP, and notices and warnings that
+; you generate yourself (by means of trigger_error()). For example, to convert
+; the warning of strlen() (without arguments) to an error, you would do:
+;
+;     ini_set('xdebug.halt_level', E_WARNING);
+;     strlen();
+;     echo "Hi!\n";
+;
+; Which will then result in the showing of the error message, and the abortion
+; of the script. ``echo "Hi!\n";`` will not be executed.
+;
+; The setting is a bit mask, so to convert all notices and warnings into errors
+; for all applications, you can set this in php.ini:
+;
+;     xdebug.halt_level=E_WARNING|E_NOTICE|E_USER_WARNING|E_USER_NOTICE
+;
+; The bitmask only supports the four level that are mentioned above.
+;
+;
+;xdebug.halt_level = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.idekey
+;
+; Type: string, Default value: *complex*
+;
+; Controls which IDE Key Xdebug should pass on to the DBGp debugger handler. The
+; default is based on environment settings. First the environment setting
+; DBGP_IDEKEY is consulted, then USER and as last USERNAME. The default is set
+; to the first environment variable that is found. If none could be found the
+; setting has as default ''. If this setting is set, it always overrides the
+; environment variables.
+;
+;
+;xdebug.idekey = *complex*
+
+; -----------------------------------------------------------------------------
+; xdebug.manual_url
+;
+; Only in Xdebug versions < 2.2.1
+;
+; Type: string, Default value: http://www.php.net
+;
+; This is the base url for the links from the function traces and error message
+; to the manual pages of the function from the message. It is advisable to set
+; this setting to use the closest mirror.
+;
+;
+;xdebug.manual_url = http://www.php.net
+
+; -----------------------------------------------------------------------------
+; xdebug.max_nesting_level
+;
+; Type: integer, Default value: 256
+;
+; Controls the protection mechanism for infinite recursion protection. The value
+; of this setting is the maximum level of nested functions that are allowed
+; before the script will be aborted.
+;
+; Before Xdebug 2.3, the default value was ``100``.
+;
+;
+;xdebug.max_nesting_level = 256
+
+; -----------------------------------------------------------------------------
+; xdebug.max_stack_frames
+;
+; Only in Xdebug versions >= 2.3
+;
+; Type: integer, Default value: -1
+;
+; Controls how many stack frames are shown in stack traces, both on the command
+; line during PHP error stack traces, as well as in the browser for HTML traces.
+;
+;
+;xdebug.max_stack_frames = -1
+
+; -----------------------------------------------------------------------------
+; xdebug.overload_var_dump
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 2
+;
+; By default Xdebug overloads var_dump() with its own improved version for
+; displaying variables when the html_errors php.ini setting is set to ``1`` or
+; ``2``. In case you do not want that, you can set this setting to ``0``, but
+; check first if it's not smarter to turn off html_errors.
+;
+; You can also use ``2`` as value for this setting. Besides formatting the
+; var_dump() output nicely, it will also add filename and line number to the
+; output. The xdebug.file_link_format setting is also respected. *(New in Xdebug
+; 2.3)*
+;
+; Before Xdebug 2.4, the default value of this setting was ``1``.
+;
+;
+;xdebug.overload_var_dump = 2
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_aggregate
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, a single profiler file will be written for
+; multiple requests. One can surf to multiple pages or reload a page to get an
+; **average** across all requests. The file will be named
+; ``.cachegrind.aggregate``. You will need to move this file to get another
+; round of aggregate data.
+;
+;
+;xdebug.profiler_aggregate = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_append
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, profiler files will not be overwritten when a
+; new request would map to the same file (depending on the
+; xdebug.profiler_output_name setting. Instead the file will be appended to with
+; the new profile.
+;
+;
+;xdebug.profiler_append = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable
+;
+; Type: integer, Default value: 0
+;
+; Enables Xdebug's profiler which creates files in the profile output directory.
+; Those files can be read by KCacheGrind to visualize your data. This setting
+; can not be set in your script with ini_set(). If you want to selectively
+; enable the profiler, please set xdebug.profiler_enable_trigger to 1
+; **instead** of using this setting.
+;
+;
+;xdebug.profiler_enable = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable_trigger
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, you can trigger the generation of profiler
+; files by using the XDEBUG_PROFILE GET/POST parameter, or set a cookie with the
+; name XDEBUG_PROFILE. This will then write the profiler data to defined
+; directory. In order to prevent the profiler to generate profile files for each
+; request, you need to set xdebug.profiler_enable to 0. Access to the trigger
+; itself can be configured through xdebug.profiler_enable_trigger_value.
+;
+;
+;xdebug.profiler_enable_trigger = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable_trigger_value
+;
+; Only in Xdebug versions > 2.3
+;
+; Type: string, Default value: ""
+;
+; This setting can be used to restrict who can make use of the XDEBUG_PROFILE
+; functionality as outlined in xdebug.profiler_enable_trigger. When changed from
+; its default value of an empty string, the value of the cookie, GET or POST
+; argument needs to match the shared secret set with this setting in order for
+; the profiler to start.
+;
+;
+;xdebug.profiler_enable_trigger_value = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_output_dir
+;
+; Type: string, Default value: /tmp
+;
+; The directory where the profiler output will be written to, make sure that the
+; user who the PHP will be running as has write permissions to that directory.
+; This setting can not be set in your script with ini_set().
+;
+;
+;xdebug.profiler_output_dir = /tmp
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_output_name
+;
+; Type: string, Default value: cachegrind.out.%p
+;
+; This setting determines the name of the file that is used to dump traces into.
+; The setting specifies the format with format specifiers, very similar to
+; sprintf() and strftime(). There are several format specifiers that can be used
+; to format the file name.
+;
+; See the xdebug.trace_output_name documentation for the supported specifiers.
+;
+;
+;xdebug.profiler_output_name = cachegrind.out.%p
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_addr_header
+;
+; Only in Xdebug versions > 2.4
+;
+; Type: string, Default value: ""
+;
+; If xdebug.remote_addr_header is configured to be a non-empty string, then the
+; value is used as key in the $SERVER superglobal array to determine which
+; header to use to find the IP address or hostname to use for 'connecting back
+; to'. This setting is only used in combination with xdebug.remote_connect_back
+; and is otherwise ignored.
+;
+;
+;xdebug.remote_addr_header = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_autostart
+;
+; Type: boolean, Default value: 0
+;
+; Normally you need to use a specific HTTP GET/POST variable to start remote
+; debugging (see Remote Debugging). When this setting is set to 1, Xdebug will
+; always attempt to start a remote debugging session and try to connect to a
+; client, even if the GET/POST/COOKIE variable was not present.
+;
+;
+;xdebug.remote_autostart = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_connect_back
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 0
+;
+; If enabled, the xdebug.remote_host setting is ignored and Xdebug will try to
+; connect to the client that made the HTTP request. It checks the
+; $_SERVER['HTTP_X_FORWARDED_FOR'] and $_SERVER['REMOTE_ADDR'] variables to find
+; out which IP address to use.
+;
+; If xdebug.remote_addr_header is configured, then the $SERVER variable with the
+; configured name will be checked before the $_SERVER['HTTP_X_FORWARDED_FOR']
+; and $_SERVER['REMOTE_ADDR'] variables.
+;
+; This setting does not apply for debugging through the CLI, as the $SERVER
+; header variables are not available there.
+;
+; Please note that there is **no** filter available, and anybody who can connect
+; to the webserver will then be able to start a debugging session, even if their
+; address does not match xdebug.remote_host.
+;
+;
+xdebug.remote_connect_back = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_cookie_expire_time
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: integer, Default value: 3600
+;
+; This setting can be used to increase (or decrease) the time that the remote
+; debugging session stays alive via the session cookie.
+;
+;
+;xdebug.remote_cookie_expire_time = 3600
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_enable
+;
+; Type: boolean, Default value: 0
+;
+; This switch controls whether Xdebug should try to contact a debug client which
+; is listening on the host and port as set with the settings xdebug.remote_host
+; and xdebug.remote_port. If a connection can not be established the script will
+; just continue as if this setting was 0.
+;
+;
+xdebug.remote_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_handler
+;
+; Type: string, Default value: dbgp
+;
+; Can be either 'php3' which selects the old PHP 3 style debugger [1] output,
+; 'gdb' which enables the GDB like debugger interface or 'dbgp' - the debugger
+; protocol [2]. The DBGp protocol is the only supported protocol.
+;
+; [1] http://www.php.net/manual/en/debugger.php
+; [2] http://xdebug.org/docs-dbgp.php
+;
+; **Note**: Xdebug 2.1 and later only support 'dbgp' as protocol.
+;
+;
+;xdebug.remote_handler = dbgp
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_host
+;
+; Type: string, Default value: localhost
+;
+; Selects the host where the debug client is running, you can either use a host
+; name or an IP address. This setting is ignored if xdebug.remote_connect_back
+; is enabled.
+;
+;
+xdebug.remote_host = 10.0.2.2
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_log
+;
+; Type: string, Default value:
+;
+; If set to a value, it is used as filename to a file to which all remote
+; debugger communications are logged. The file is always opened in append-mode,
+; and will therefore not be overwritten by default. There is no concurrency
+; protection available. The format of the file looks something like:
+;
+;     Log opened at 2007-05-27 14:28:15
+;     -> <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/x ... ight></init>
+;
+;     <- step_into -i 1
+;     -> <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/db ... ></response>
+;
+;
+;xdebug.remote_log ="/tmp/xdebug.log"
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_mode
+;
+; Type: string, Default value: req
+;
+; Selects when a debug connection is initiated. This setting can have two
+; different values:
+;
+; req
+;     Xdebug will try to connect to the debug client as soon as the script
+;     starts.
+;
+; jit
+;     Xdebug will only try to connect to the debug client as soon as an error
+;     condition occurs.
+;
+;
+xdebug.remote_mode = req
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_port
+;
+; Type: integer, Default value: 9000
+;
+; The port to which Xdebug tries to connect on the remote host. Port 9000 is the
+; default for both the client and the bundled debugclient. As many clients use
+; this port number, it is best to leave this setting unchanged.
+;
+;
+xdebug.remote_port = 9001
+
+; -----------------------------------------------------------------------------
+; xdebug.scream
+;
+; Only in Xdebug versions >= 2.1
+;
+; Type: boolean, Default value: 0
+;
+; If this setting is 1, then Xdebug will disable the @ (shut-up) operator so
+; that notices, warnings and errors are no longer hidden.
+;
+;
+;xdebug.scream = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_error_trace
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, Xdebug will show a stack trace whenever an
+; Error is raised - even if this Error is actually caught.
+;
+;
+;xdebug.show_error_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_exception_trace
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, Xdebug will show a stack trace whenever an
+; Exception or Error is raised - even if this Exception or Error is actually
+; caught.
+;
+; Error 'exceptions' were introduced in PHP 7.
+;
+;
+;xdebug.show_exception_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_local_vars
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to something != 0 Xdebug's generated stack dumps in
+; error situations will also show all variables in the top-most scope. Beware
+; that this might generate a lot of information, and is therefore turned off by
+; default.
+;
+;
+;xdebug.show_local_vars = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_mem_delta
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to something != 0 Xdebug's human-readable generated
+; trace files will show the difference in memory usage between function calls.
+; If Xdebug is configured to generate computer-readable trace files then they
+; will always show this information.
+;
+;
+;xdebug.show_mem_delta = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_enable_trigger
+;
+; Only in Xdebug versions > 2.2
+;
+; Type: boolean, Default value: 0
+;
+; When this setting is set to 1, you can trigger the generation of trace files
+; by using the XDEBUG_TRACE GET/POST parameter, or set a cookie with the name
+; XDEBUG_TRACE. This will then write the trace data to defined directory. In
+; order to prevent Xdebug to generate trace files for each request, you need to
+; set xdebug.auto_trace to 0. Access to the trigger itself can be configured
+; through xdebug.trace_enable_trigger_value.
+;
+;
+;xdebug.trace_enable_trigger = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_enable_trigger_value
+;
+; Only in Xdebug versions > 2.3
+;
+; Type: string, Default value: ""
+;
+; This setting can be used to restrict who can make use of the XDEBUG_TRACE
+; functionality as outlined in xdebug.trace_enable_trigger. When changed from
+; its default value of an empty string, the value of the cookie, GET or POST
+; argument needs to match the shared secret set with this setting in order for
+; the trace file to be generated.
+;
+;
+;xdebug.trace_enable_trigger_value = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_format
+;
+; Type: integer, Default value: 0
+;
+; The format of the trace file.
+;
+; =====  ==============================================================================
+; Value  Description
+; =====  ==============================================================================
+; 0      shows a human readable indented trace file with:
+;
+;        *time index*, *memory usage*, *memory delta* (if the setting
+;        xdebug.show_mem_delta is enabled), *level*, *function name*, *function
+;        parameters* (if the setting xdebug.collect_params is enabled), *filename* and
+;        *line number*.
+; -----  ------------------------------------------------------------------------------
+; 1      writes a computer readable format which has two different records. There are
+;        different records for entering a stack frame, and leaving a stack frame. The
+;        table below lists the fields in each type of record. Fields are tab separated.
+; -----  ------------------------------------------------------------------------------
+; 2      writes a trace formatted in (simple) HTML.
+; =====  ==============================================================================
+;
+; Fields for the computerized format:
+;
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+; Record type  1      2            3            4           5             6              7                                            8                                 9         10           11                 12 - ...
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+; Entry        level  function #  always '0'  time index  memory usage  function name  user-defined (1) or internal function (0)  name of the include/require file  filename  line number  no. of parameters  parameters (as many as specified in field 11) - tab separated
+; -----------  -----  -----------  -----------  ----------  ------------  -------------  -------------------------------------------  --------------------------------  --------  -----------  -----------------  -------------------------------------------------------------
+; Exit         level  function #  always '1'  time index  memory usage  empty
+; -----------  -----  -----------  -----------  ----------  ------------  -------------  -------------------------------------------  --------------------------------  --------  -----------  -----------------  -------------------------------------------------------------
+; Return       level  function #  always 'R'  empty       return value  empty
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+;
+; See the introduction of Function Traces for a few examples.
+;
+;
+;xdebug.trace_format = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_options
+;
+; Type: integer, Default value: 0
+;
+; When set to '1' the trace files will be appended to, instead of being
+; overwritten in subsequent requests.
+;
+;
+;xdebug.trace_options = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_output_dir
+;
+; Type: string, Default value: /tmp
+;
+; The directory where the tracing files will be written to, make sure that the
+; user who the PHP will be running as has write permissions to that directory.
+;
+;
+;xdebug.trace_output_dir = /tmp
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_output_name
+;
+; Type: string, Default value: trace.%c
+;
+; This setting determines the name of the file that is used to dump traces into.
+; The setting specifies the format with format specifiers, very similar to
+; sprintf() and strftime(). There are several format specifiers that can be used
+; to format the file name. The '.xt' extension is always added automatically.
+;
+; The possible format specifiers are:
+;
+; =========  ======================================  =================  ====================================================
+; Specifier  Meaning                                 Example Format     Example Filename
+; =========  ======================================  =================  ====================================================
+; %c         crc32 of the current working directory  trace.%c           trace.1258863198.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %p         pid                                     trace.%p           trace.5174.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %r         random number                           trace.%r           trace.072db0.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %s         script name 2                           cachegrind.out.%s  cachegrind.out._home_httpd_html_test_xdebug_test_php
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %t         timestamp (seconds)                     trace.%t           trace.1179434742.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %u         timestamp (microseconds)                trace.%u           trace.1179434749_642382.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %H         $_SERVER['HTTP_HOST']                   trace.%H           trace.kossu.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %R         $_SERVER['REQUEST_URI']                 trace.%R           trace._test_xdebug_test_php_var=1_var2=2.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %U         $_SERVER['UNIQUE_ID']                   trace.%U           trace.TRX4n38AAAEAAB9gBFkAAAAB.xt
+;
+;            3
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %S         session_id (from $_COOKIE if set)       trace.%S           trace.c70c1ec2375af58f74b390bbdd2a679d.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %%         literal %                               trace.%%           trace.%%.xt
+; =========  ======================================  =================  ====================================================
+;
+; 2 This one is not available for trace file names.
+;
+; 3 New in version 2.2. This one is set by Apache's mod_unique_id module [1]
+;
+; [1] http://httpd.apache.org/docs/2.2/en/mod/mod_unique_id.html
+;
+;
+;xdebug.trace_output_name = trace.%c
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_children
+;
+; Type: integer, Default value: 128
+;
+; Controls the amount of array children and object's properties are shown when
+; variables are displayed with either xdebug_var_dump(), xdebug.show_local_vars
+; or through Function Traces.
+;
+; To disable any limitation, use *-1* as value.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_children = 128
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_data
+;
+; Type: integer, Default value: 512
+;
+; Controls the maximum string length that is shown when variables are displayed
+; with either xdebug_var_dump(), xdebug.show_local_vars or through Function
+; Traces.
+;
+; To disable any limitation, use *-1* as value.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_data = 512
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_depth
+;
+; Type: integer, Default value: 3
+;
+; Controls how many nested levels of array elements and object properties are
+; when variables are displayed with either xdebug_var_dump(),
+; xdebug.show_local_vars or through Function Traces.
+;
+; The maximum value you can select is 1023. You can also use *-1* as value to
+; select this maximum number.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_depth = 3
+

--- a/ansible/roles/php-72/tasks/main.yml
+++ b/ansible/roles/php-72/tasks/main.yml
@@ -31,6 +31,12 @@
     src: php.ini
     dest: /etc/opt/remi/php72/php.ini
 
+- name: xdebug.ini file
+  template:
+    src: xdebug.ini
+    dest: /etc/opt/remi/php72/php.d/15-xdebug.ini
+  when: xdebug|d(False) == True
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-72/tasks/main.yml
+++ b/ansible/roles/php-72/tasks/main.yml
@@ -37,6 +37,16 @@
     dest: /etc/opt/remi/php72/php.d/15-xdebug.ini
   when: xdebug|d(False) == True
 
+- name: edit xdebug.idekey value
+  lineinfile:
+    path: /etc/opt/remi/php72/php.d/15-xdebug.ini
+    regexp: '^;xdebug\.idekey = \*complex\*'
+    line: 'xdebug.idekey = {{ xdebug_ide_key }}'
+    state: present
+  when:
+    - xdebug|d(False) == True
+    - xdebug_ide_key is defined
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-72/templates/xdebug.ini
+++ b/ansible/roles/php-72/templates/xdebug.ini
@@ -1,0 +1,1024 @@
+; Enable xdebug extension module
+zend_extension=xdebug.so
+
+; Configuration
+; See https://xdebug.org/docs/all_settings
+
+
+; -----------------------------------------------------------------------------
+; xdebug.auto_trace
+;
+; Type: boolean, Default value: 0
+;
+; When this setting is set to on, the tracing of function calls will be enabled
+; just before the script is run. This makes it possible to trace code in the
+; auto_prepend_file [1].
+;
+; [1] http://php.net/manual/en/ini.core.php#ini.auto-prepend-file
+;
+;
+;xdebug.auto_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.cli_color
+;
+; Only in Xdebug versions > 2.2
+;
+; Type: integer, Default value: 0
+;
+; If this setting is 1, Xdebug will color var_dumps and stack traces output when
+; in CLI mode and when the output is a tty. On Windows, the ANSICON [1] tool
+; needs to be installed.
+;
+; [1] http://adoxa.110mb.com/ansicon/
+;
+; If the setting is 2, then Xdebug will always color var_dumps and stack trace,
+; no matter whether it's connected to a tty or whether ANSICON is installed. In
+; this case, you might end up seeing escape codes.
+;
+; See this article [1] for some more information.
+;
+; [1] https://drck.me/clicolor-9cr
+;
+;
+;xdebug.cli_color = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_assignments
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should add variable
+; assignments to function traces.
+;
+;
+;xdebug.collect_assignments = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_includes
+;
+; Type: boolean, Default value: 1
+;
+; This setting, defaulting to 1, controls whether Xdebug should write the
+; filename used in include(), include_once(), require() or require_once() to the
+; trace files.
+;
+;
+;xdebug.collect_includes = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_params
+;
+; Type: integer, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should collect the
+; parameters passed to functions when a function call is recorded in either the
+; function trace or the stack trace.
+;
+; The setting defaults to 0 because for very large scripts it may use huge
+; amounts of memory and therefore make it impossible for the huge script to run.
+; You can most safely turn this setting on, but you can expect some problems in
+; scripts with a lot of function calls and/or huge data structures as
+; parameters. Xdebug 2 will not have this problem with increased memory usage,
+; as it will never store this information in memory. Instead it will only be
+; written to disk. This means that you need to have a look at the disk usage
+; though.
+;
+; This setting can have four different values. For each of the values a
+; different amount of information is shown. Below you will see what information
+; each of the values provides. See also the introduction of the feature Stack
+; Traces for a few screenshots.
+;
+; =====  ========================================================================
+; Value  Argument Information Shown
+; =====  ========================================================================
+; 0      None.
+; -----  ------------------------------------------------------------------------
+; 1      Type and number of elements (f.e. string(6), array(8)).
+; -----  ------------------------------------------------------------------------
+; 2      Type and number of elements, with a tool tip for the full information 1.
+; -----  ------------------------------------------------------------------------
+; 3      Full variable contents (with the limits respected as set by
+;        xdebug.var_display_max_children, xdebug.var_display_max_data and
+;        xdebug.var_display_max_depth.
+; -----  ------------------------------------------------------------------------
+; 4      Full variable contents and variable name.
+; -----  ------------------------------------------------------------------------
+; 5      PHP serialized variable contents, without the name.
+;
+;        (New in Xdebug 2.3)
+; =====  ========================================================================
+;
+; 1 in the CLI version of PHP it will not have the tool tip, nor in output
+; files.
+;
+;
+;xdebug.collect_params = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_return
+;
+; Type: boolean, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should write the return
+; value of function calls to the trace files.
+;
+; For computerized trace files (xdebug.trace_format=1) this only works from
+; Xdebug 2.3 onwards.
+;
+;
+;xdebug.collect_return = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_vars
+;
+; Type: boolean, Default value: 0
+;
+; This setting tells Xdebug to gather information about which variables are used
+; in a certain scope. This analysis can be quite slow as Xdebug has to reverse
+; engineer PHP's opcode arrays. This setting will not record which values the
+; different variables have, for that use xdebug.collect_params. This setting
+; needs to be enabled only if you wish to use xdebug_get_declared_vars().
+;
+;
+;xdebug.collect_vars = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.coverage_enable
+;
+; Only in Xdebug versions >= 2.2
+;
+; Type: boolean, Default value: 1
+;
+; If this setting is set to 0, then Xdebug will not set-up internal structures
+; to allow code coverage. This speeds up Xdebug quite a bit, but of course, Code
+; Coverage Analysis won't work.
+;
+;
+;xdebug.coverage_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.default_enable
+;
+; Type: boolean, Default value: 1
+;
+; If this setting is 1, then stacktraces will be shown by default on an error
+; event. You can disable showing stacktraces from your code with
+; xdebug_disable(). As this is one of the basic functions of Xdebug, it is
+; advisable to leave this setting set to 1.
+;
+;
+;xdebug.default_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump.*
+;
+; Type: string, Default value: Empty
+;
+; * can be any of COOKIE, FILES, GET, POST, REQUEST, SERVER, SESSION. These
+; seven settings control which data from the superglobals is shown when an error
+; situation occurs.
+;
+; Each of those php.ini setting can consist of a comma seperated list of
+; variables from this superglobal to dump, or ``*`` for all of them. Make sure
+; you do not add spaces in this setting.
+;
+; In order to dump the REMOTE_ADDR and the REQUEST_METHOD when an error occurs,
+; and all GET parameters, add these settings:
+;
+;     xdebug.dump.SERVER = REMOTE_ADDR,REQUEST_METHOD
+;     xdebug.dump.GET = *
+;
+;
+;xdebug.dump.* = Empty
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_globals
+;
+; Type: boolean, Default value: 1
+;
+; Controls whether the values of the superglobals as defined by the
+; xdebug.dump.* settings should be shown or not.
+;
+;
+;xdebug.dump_globals = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_once
+;
+; Type: boolean, Default value: 1
+;
+; Controls whether the values of the superglobals should be dumped on all error
+; situations (set to 0) or only on the first (set to 1).
+;
+;
+;xdebug.dump_once = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_undefined
+;
+; Type: boolean, Default value: 0
+;
+; If you want to dump undefined values from the superglobals you should set this
+; setting to 1, otherwise leave it set to 0.
+;
+;
+;xdebug.dump_undefined = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.extended_info
+;
+; Type: integer, Default value: 1
+;
+; Controls whether Xdebug should enforce 'extended_info' mode for the PHP
+; parser; this allows Xdebug to do file/line breakpoints with the remote
+; debugger. When tracing or profiling scripts you generally want to turn off
+; this option as PHP's generated oparrays will increase with about a third of
+; the size slowing down your scripts. This setting can not be set in your
+; scripts with ini_set(), but only in php.ini.
+;
+;
+;xdebug.extended_info = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.file_link_format
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: string, Default value:
+;
+; This setting determines the format of the links that are made in the display
+; of stack traces where file names are used. This allows IDEs to set up a
+; link-protocol that makes it possible to go directly to a line and file by
+; clicking on the filenames that Xdebug shows in stack traces. An example format
+; might look like:
+;
+;     myide://%f@%l
+;
+; The possible format specifiers are:
+;
+; =========  ===============
+; Specifier  Meaning
+; =========  ===============
+; %f         the filename
+; ---------  ---------------
+; %l         the line number
+; =========  ===============
+;
+; For various IDEs/OSses there are some instructions listed on how to make this
+; work:
+;
+; ----------------
+; Firefox on Linux
+; ----------------
+;
+; - Open
+;
+;   about:config
+;
+; - Add a new boolean setting "network.protocol-handler.expose.xdebug" and set
+;   it to "false"
+;
+; - Add the following into a shell script
+;
+;   ``~/bin/ff-xdebug.sh``:
+;
+;     #! /bin/sh
+;
+;     f=`echo $1 | cut -d @ -f 1 | sed 's/xdebug:\/\///'`
+;     l=`echo $1 | cut -d @ -f 2`
+;
+;   Add to that one of (depending whether you have komodo, gvim or netbeans):
+;
+;   - komodo $f -l $l
+;
+;   - gvim --remote-tab +$l $f
+;
+;   - netbeans "$f:$l"
+;
+; - Make the script executable with
+;
+; chmod +x ~/bin/ff-xdebug.sh
+;
+; - Set the xdebug.file_link_format setting to
+;
+; xdebug://%f@%l
+;
+; --------------------
+; Windows and netbeans
+; --------------------
+;
+; - Create the file
+;
+;   ``netbeans.bat`` and save it in your path ( ``C:\Windows`` will work):
+;
+;     @echo off
+;     setlocal enableextensions enabledelayedexpansion
+;     set NETBEANS=%1
+;     set FILE=%~2
+;     %NETBEANS% --nosplash --console suppress --open "%FILE:~19%"
+;     nircmd win activate process netbeans.exe
+;
+;   **Note:** Remove the last line if you don't have ``nircmd``.
+;
+; - Save the following code as
+;
+;   ``netbeans_protocol.reg``:
+;
+;     Windows Registry Editor Version 5.00
+;
+;     [HKEY_CLASSES_ROOT\netbeans]
+;     "URL Protocol"=""
+;     @="URL:Netbeans Protocol"
+;
+;     [HKEY_CLASSES_ROOT\netbeans\DefaultIcon]
+;     @="\"C:\\Program Files\\NetBeans 7.1.1\\bin\\netbeans.exe,1\""
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell]
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell\open]
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell\open\command]
+;     @="\"C:\\Windows\\netbeans.bat\" \"C:\\Program Files\\NetBeans 7.1.1\\bin\\netbeans.exe\" \"%1\""
+;
+;   **Note:** Make sure to change the path to Netbeans (twice), as well as the
+;   ``netbeans.bat`` batch file if you saved it somewhere else than
+;   ``C:\Windows\``.
+;
+; - Double click on the
+;
+;   ``netbeans_protocol.reg`` file to import it into the registry.
+;
+; - Set the xdebug.file_link_format setting to
+;
+; xdebug.file_link_format =
+;     "netbeans://open/?f=%f:%l"
+;
+;
+;xdebug.file_link_format =
+
+; -----------------------------------------------------------------------------
+; xdebug.force_display_errors
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; If this setting is set to ``1`` then errors will **always** be displayed, no
+; matter what the setting of PHP's display_errors [1] is.
+;
+; [1] http://php.net/manual/en/errorfunc.configuration.php#ini.display-errors
+;
+;
+;xdebug.force_display_errors = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.force_error_reporting
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; This setting is a bitmask, like error_reporting [1]. This bitmask will be
+; logically ORed with the bitmask represented by error_reporting [2] to dermine
+; which errors should be displayed. This setting can only be made in php.ini and
+; allows you to force certain errors from being shown no matter what an
+; application does with ini_set() [3].
+;
+; [1] http://php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+; [2] http://php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+; [3] http://php.net/manual/en/function.ini-set.php
+;
+;
+;xdebug.force_error_reporting = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.halt_level
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; This setting allows you to configure a mask that determines whether, and
+; which, notices and/or warnings get converted to errors. You can configure
+; notices and warnings that are generated by PHP, and notices and warnings that
+; you generate yourself (by means of trigger_error()). For example, to convert
+; the warning of strlen() (without arguments) to an error, you would do:
+;
+;     ini_set('xdebug.halt_level', E_WARNING);
+;     strlen();
+;     echo "Hi!\n";
+;
+; Which will then result in the showing of the error message, and the abortion
+; of the script. ``echo "Hi!\n";`` will not be executed.
+;
+; The setting is a bit mask, so to convert all notices and warnings into errors
+; for all applications, you can set this in php.ini:
+;
+;     xdebug.halt_level=E_WARNING|E_NOTICE|E_USER_WARNING|E_USER_NOTICE
+;
+; The bitmask only supports the four level that are mentioned above.
+;
+;
+;xdebug.halt_level = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.idekey
+;
+; Type: string, Default value: *complex*
+;
+; Controls which IDE Key Xdebug should pass on to the DBGp debugger handler. The
+; default is based on environment settings. First the environment setting
+; DBGP_IDEKEY is consulted, then USER and as last USERNAME. The default is set
+; to the first environment variable that is found. If none could be found the
+; setting has as default ''. If this setting is set, it always overrides the
+; environment variables.
+;
+;
+xdebug.idekey = PHPSTORM
+
+; -----------------------------------------------------------------------------
+; xdebug.manual_url
+;
+; Only in Xdebug versions < 2.2.1
+;
+; Type: string, Default value: http://www.php.net
+;
+; This is the base url for the links from the function traces and error message
+; to the manual pages of the function from the message. It is advisable to set
+; this setting to use the closest mirror.
+;
+;
+;xdebug.manual_url = http://www.php.net
+
+; -----------------------------------------------------------------------------
+; xdebug.max_nesting_level
+;
+; Type: integer, Default value: 256
+;
+; Controls the protection mechanism for infinite recursion protection. The value
+; of this setting is the maximum level of nested functions that are allowed
+; before the script will be aborted.
+;
+; Before Xdebug 2.3, the default value was ``100``.
+;
+;
+;xdebug.max_nesting_level = 256
+
+; -----------------------------------------------------------------------------
+; xdebug.max_stack_frames
+;
+; Only in Xdebug versions >= 2.3
+;
+; Type: integer, Default value: -1
+;
+; Controls how many stack frames are shown in stack traces, both on the command
+; line during PHP error stack traces, as well as in the browser for HTML traces.
+;
+;
+;xdebug.max_stack_frames = -1
+
+; -----------------------------------------------------------------------------
+; xdebug.overload_var_dump
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 2
+;
+; By default Xdebug overloads var_dump() with its own improved version for
+; displaying variables when the html_errors php.ini setting is set to ``1`` or
+; ``2``. In case you do not want that, you can set this setting to ``0``, but
+; check first if it's not smarter to turn off html_errors.
+;
+; You can also use ``2`` as value for this setting. Besides formatting the
+; var_dump() output nicely, it will also add filename and line number to the
+; output. The xdebug.file_link_format setting is also respected. *(New in Xdebug
+; 2.3)*
+;
+; Before Xdebug 2.4, the default value of this setting was ``1``.
+;
+;
+;xdebug.overload_var_dump = 2
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_aggregate
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, a single profiler file will be written for
+; multiple requests. One can surf to multiple pages or reload a page to get an
+; **average** across all requests. The file will be named
+; ``.cachegrind.aggregate``. You will need to move this file to get another
+; round of aggregate data.
+;
+;
+;xdebug.profiler_aggregate = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_append
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, profiler files will not be overwritten when a
+; new request would map to the same file (depending on the
+; xdebug.profiler_output_name setting. Instead the file will be appended to with
+; the new profile.
+;
+;
+;xdebug.profiler_append = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable
+;
+; Type: integer, Default value: 0
+;
+; Enables Xdebug's profiler which creates files in the profile output directory.
+; Those files can be read by KCacheGrind to visualize your data. This setting
+; can not be set in your script with ini_set(). If you want to selectively
+; enable the profiler, please set xdebug.profiler_enable_trigger to 1
+; **instead** of using this setting.
+;
+;
+;xdebug.profiler_enable = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable_trigger
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, you can trigger the generation of profiler
+; files by using the XDEBUG_PROFILE GET/POST parameter, or set a cookie with the
+; name XDEBUG_PROFILE. This will then write the profiler data to defined
+; directory. In order to prevent the profiler to generate profile files for each
+; request, you need to set xdebug.profiler_enable to 0. Access to the trigger
+; itself can be configured through xdebug.profiler_enable_trigger_value.
+;
+;
+;xdebug.profiler_enable_trigger = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable_trigger_value
+;
+; Only in Xdebug versions > 2.3
+;
+; Type: string, Default value: ""
+;
+; This setting can be used to restrict who can make use of the XDEBUG_PROFILE
+; functionality as outlined in xdebug.profiler_enable_trigger. When changed from
+; its default value of an empty string, the value of the cookie, GET or POST
+; argument needs to match the shared secret set with this setting in order for
+; the profiler to start.
+;
+;
+;xdebug.profiler_enable_trigger_value = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_output_dir
+;
+; Type: string, Default value: /tmp
+;
+; The directory where the profiler output will be written to, make sure that the
+; user who the PHP will be running as has write permissions to that directory.
+; This setting can not be set in your script with ini_set().
+;
+;
+;xdebug.profiler_output_dir = /tmp
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_output_name
+;
+; Type: string, Default value: cachegrind.out.%p
+;
+; This setting determines the name of the file that is used to dump traces into.
+; The setting specifies the format with format specifiers, very similar to
+; sprintf() and strftime(). There are several format specifiers that can be used
+; to format the file name.
+;
+; See the xdebug.trace_output_name documentation for the supported specifiers.
+;
+;
+;xdebug.profiler_output_name = cachegrind.out.%p
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_addr_header
+;
+; Only in Xdebug versions > 2.4
+;
+; Type: string, Default value: ""
+;
+; If xdebug.remote_addr_header is configured to be a non-empty string, then the
+; value is used as key in the $SERVER superglobal array to determine which
+; header to use to find the IP address or hostname to use for 'connecting back
+; to'. This setting is only used in combination with xdebug.remote_connect_back
+; and is otherwise ignored.
+;
+;
+;xdebug.remote_addr_header = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_autostart
+;
+; Type: boolean, Default value: 0
+;
+; Normally you need to use a specific HTTP GET/POST variable to start remote
+; debugging (see Remote Debugging). When this setting is set to 1, Xdebug will
+; always attempt to start a remote debugging session and try to connect to a
+; client, even if the GET/POST/COOKIE variable was not present.
+;
+;
+;xdebug.remote_autostart = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_connect_back
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 0
+;
+; If enabled, the xdebug.remote_host setting is ignored and Xdebug will try to
+; connect to the client that made the HTTP request. It checks the
+; $_SERVER['HTTP_X_FORWARDED_FOR'] and $_SERVER['REMOTE_ADDR'] variables to find
+; out which IP address to use.
+;
+; If xdebug.remote_addr_header is configured, then the $SERVER variable with the
+; configured name will be checked before the $_SERVER['HTTP_X_FORWARDED_FOR']
+; and $_SERVER['REMOTE_ADDR'] variables.
+;
+; This setting does not apply for debugging through the CLI, as the $SERVER
+; header variables are not available there.
+;
+; Please note that there is **no** filter available, and anybody who can connect
+; to the webserver will then be able to start a debugging session, even if their
+; address does not match xdebug.remote_host.
+;
+;
+xdebug.remote_connect_back = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_cookie_expire_time
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: integer, Default value: 3600
+;
+; This setting can be used to increase (or decrease) the time that the remote
+; debugging session stays alive via the session cookie.
+;
+;
+;xdebug.remote_cookie_expire_time = 3600
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_enable
+;
+; Type: boolean, Default value: 0
+;
+; This switch controls whether Xdebug should try to contact a debug client which
+; is listening on the host and port as set with the settings xdebug.remote_host
+; and xdebug.remote_port. If a connection can not be established the script will
+; just continue as if this setting was 0.
+;
+;
+xdebug.remote_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_handler
+;
+; Type: string, Default value: dbgp
+;
+; Can be either 'php3' which selects the old PHP 3 style debugger [1] output,
+; 'gdb' which enables the GDB like debugger interface or 'dbgp' - the debugger
+; protocol [2]. The DBGp protocol is the only supported protocol.
+;
+; [1] http://www.php.net/manual/en/debugger.php
+; [2] https://xdebug.org/docs-dbgp.php
+;
+; **Note**: Xdebug 2.1 and later only support 'dbgp' as protocol.
+;
+;
+;xdebug.remote_handler = dbgp
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_host
+;
+; Type: string, Default value: localhost
+;
+; Selects the host where the debug client is running, you can either use a host
+; name or an IP address. This setting is ignored if xdebug.remote_connect_back
+; is enabled.
+;
+;
+xdebug.remote_host = 10.0.2.2
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_log
+;
+; Type: string, Default value:
+;
+; If set to a value, it is used as filename to a file to which all remote
+; debugger communications are logged. The file is always opened in append-mode,
+; and will therefore not be overwritten by default. There is no concurrency
+; protection available. The format of the file looks something like:
+;
+;     Log opened at 2007-05-27 14:28:15
+;     -> <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/x ... ight></init>
+;
+;     <- step_into -i 1
+;     -> <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/db ... ></response>
+;
+;
+;xdebug.remote_log ="/tmp/xdebug.log"
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_mode
+;
+; Type: string, Default value: req
+;
+; Selects when a debug connection is initiated. This setting can have two
+; different values:
+;
+; req
+;     Xdebug will try to connect to the debug client as soon as the script
+;     starts.
+;
+; jit
+;     Xdebug will only try to connect to the debug client as soon as an error
+;     condition occurs.
+;
+;
+xdebug.remote_mode = req
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_port
+;
+; Type: integer, Default value: 9000
+;
+; The port to which Xdebug tries to connect on the remote host. Port 9000 is the
+; default for both the client and the bundled debugclient. As many clients use
+; this port number, it is best to leave this setting unchanged.
+;
+;
+xdebug.remote_port = 9001
+
+; -----------------------------------------------------------------------------
+; xdebug.scream
+;
+; Only in Xdebug versions >= 2.1
+;
+; Type: boolean, Default value: 0
+;
+; If this setting is 1, then Xdebug will disable the @ (shut-up) operator so
+; that notices, warnings and errors are no longer hidden.
+;
+;
+;xdebug.scream = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_error_trace
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, Xdebug will show a stack trace whenever an
+; Error is raised - even if this Error is actually caught.
+;
+;
+;xdebug.show_error_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_exception_trace
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, Xdebug will show a stack trace whenever an
+; Exception or Error is raised - even if this Exception or Error is actually
+; caught.
+;
+; Error 'exceptions' were introduced in PHP 7.
+;
+;
+;xdebug.show_exception_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_local_vars
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to something != 0 Xdebug's generated stack dumps in
+; error situations will also show all variables in the top-most scope. Beware
+; that this might generate a lot of information, and is therefore turned off by
+; default.
+;
+;
+;xdebug.show_local_vars = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_mem_delta
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to something != 0 Xdebug's human-readable generated
+; trace files will show the difference in memory usage between function calls.
+; If Xdebug is configured to generate computer-readable trace files then they
+; will always show this information.
+;
+;
+;xdebug.show_mem_delta = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_enable_trigger
+;
+; Only in Xdebug versions > 2.2
+;
+; Type: boolean, Default value: 0
+;
+; When this setting is set to 1, you can trigger the generation of trace files
+; by using the XDEBUG_TRACE GET/POST parameter, or set a cookie with the name
+; XDEBUG_TRACE. This will then write the trace data to defined directory. In
+; order to prevent Xdebug to generate trace files for each request, you need to
+; set xdebug.auto_trace to 0. Access to the trigger itself can be configured
+; through xdebug.trace_enable_trigger_value.
+;
+;
+;xdebug.trace_enable_trigger = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_enable_trigger_value
+;
+; Only in Xdebug versions > 2.3
+;
+; Type: string, Default value: ""
+;
+; This setting can be used to restrict who can make use of the XDEBUG_TRACE
+; functionality as outlined in xdebug.trace_enable_trigger. When changed from
+; its default value of an empty string, the value of the cookie, GET or POST
+; argument needs to match the shared secret set with this setting in order for
+; the trace file to be generated.
+;
+;
+;xdebug.trace_enable_trigger_value = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_format
+;
+; Type: integer, Default value: 0
+;
+; The format of the trace file.
+;
+; =====  ==============================================================================
+; Value  Description
+; =====  ==============================================================================
+; 0      shows a human readable indented trace file with:
+;
+;        *time index*, *memory usage*, *memory delta* (if the setting
+;        xdebug.show_mem_delta is enabled), *level*, *function name*, *function
+;        parameters* (if the setting xdebug.collect_params is enabled), *filename* and
+;        *line number*.
+; -----  ------------------------------------------------------------------------------
+; 1      writes a computer readable format which has two different records. There are
+;        different records for entering a stack frame, and leaving a stack frame. The
+;        table below lists the fields in each type of record. Fields are tab separated.
+; -----  ------------------------------------------------------------------------------
+; 2      writes a trace formatted in (simple) HTML.
+; =====  ==============================================================================
+;
+; Fields for the computerized format:
+;
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+; Record type  1      2            3            4           5             6              7                                            8                                 9         10           11                 12 - ...
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+; Entry        level  function #  always '0'  time index  memory usage  function name  user-defined (1) or internal function (0)  name of the include/require file  filename  line number  no. of parameters  parameters (as many as specified in field 11) - tab separated
+; -----------  -----  -----------  -----------  ----------  ------------  -------------  -------------------------------------------  --------------------------------  --------  -----------  -----------------  -------------------------------------------------------------
+; Exit         level  function #  always '1'  time index  memory usage  empty
+; -----------  -----  -----------  -----------  ----------  ------------  -------------  -------------------------------------------  --------------------------------  --------  -----------  -----------------  -------------------------------------------------------------
+; Return       level  function #  always 'R'  empty       return value  empty
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+;
+; See the introduction of Function Traces for a few examples.
+;
+;
+;xdebug.trace_format = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_options
+;
+; Type: integer, Default value: 0
+;
+; When set to '1' the trace files will be appended to, instead of being
+; overwritten in subsequent requests.
+;
+;
+;xdebug.trace_options = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_output_dir
+;
+; Type: string, Default value: /tmp
+;
+; The directory where the tracing files will be written to, make sure that the
+; user who the PHP will be running as has write permissions to that directory.
+;
+;
+;xdebug.trace_output_dir = /tmp
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_output_name
+;
+; Type: string, Default value: trace.%c
+;
+; This setting determines the name of the file that is used to dump traces into.
+; The setting specifies the format with format specifiers, very similar to
+; sprintf() and strftime(). There are several format specifiers that can be used
+; to format the file name. The '.xt' extension is always added automatically.
+;
+; The possible format specifiers are:
+;
+; =========  ======================================  =================  ====================================================
+; Specifier  Meaning                                 Example Format     Example Filename
+; =========  ======================================  =================  ====================================================
+; %c         crc32 of the current working directory  trace.%c           trace.1258863198.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %p         pid                                     trace.%p           trace.5174.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %r         random number                           trace.%r           trace.072db0.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %s         script name 2                           cachegrind.out.%s  cachegrind.out._home_httpd_html_test_xdebug_test_php
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %t         timestamp (seconds)                     trace.%t           trace.1179434742.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %u         timestamp (microseconds)                trace.%u           trace.1179434749_642382.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %H         $_SERVER['HTTP_HOST']                   trace.%H           trace.kossu.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %R         $_SERVER['REQUEST_URI']                 trace.%R           trace._test_xdebug_test_php_var=1_var2=2.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %U         $_SERVER['UNIQUE_ID']                   trace.%U           trace.TRX4n38AAAEAAB9gBFkAAAAB.xt
+;
+;            3
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %S         session_id (from $_COOKIE if set)       trace.%S           trace.c70c1ec2375af58f74b390bbdd2a679d.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %%         literal %                               trace.%%           trace.%%.xt
+; =========  ======================================  =================  ====================================================
+;
+; 2 This one is not available for trace file names.
+;
+; 3 New in version 2.2. This one is set by Apache's mod_unique_id module [1]
+;
+; [1] http://httpd.apache.org/docs/2.2/en/mod/mod_unique_id.html
+;
+;
+;xdebug.trace_output_name = trace.%c
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_children
+;
+; Type: integer, Default value: 128
+;
+; Controls the amount of array children and object's properties are shown when
+; variables are displayed with either xdebug_var_dump(), xdebug.show_local_vars
+; or through Function Traces.
+;
+; To disable any limitation, use *-1* as value.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_children = 128
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_data
+;
+; Type: integer, Default value: 512
+;
+; Controls the maximum string length that is shown when variables are displayed
+; with either xdebug_var_dump(), xdebug.show_local_vars or through Function
+; Traces.
+;
+; To disable any limitation, use *-1* as value.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_data = 512
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_depth
+;
+; Type: integer, Default value: 3
+;
+; Controls how many nested levels of array elements and object properties are
+; when variables are displayed with either xdebug_var_dump(),
+; xdebug.show_local_vars or through Function Traces.
+;
+; The maximum value you can select is 1023. You can also use *-1* as value to
+; select this maximum number.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_depth = 3
+

--- a/ansible/roles/php-72/templates/xdebug.ini
+++ b/ansible/roles/php-72/templates/xdebug.ini
@@ -437,7 +437,7 @@ zend_extension=xdebug.so
 ; environment variables.
 ;
 ;
-xdebug.idekey = PHPSTORM
+;xdebug.idekey = *complex*
 
 ; -----------------------------------------------------------------------------
 ; xdebug.manual_url

--- a/ansible/roles/php-73/tasks/main.yml
+++ b/ansible/roles/php-73/tasks/main.yml
@@ -31,6 +31,12 @@
     src: php.ini
     dest: /etc/opt/remi/php73/php.ini
 
+- name: xdebug.ini file
+  template:
+    src: xdebug.ini
+    dest: /etc/opt/remi/php73/php.d/15-xdebug.ini
+  when: xdebug|d(False) == True
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-73/tasks/main.yml
+++ b/ansible/roles/php-73/tasks/main.yml
@@ -37,6 +37,16 @@
     dest: /etc/opt/remi/php73/php.d/15-xdebug.ini
   when: xdebug|d(False) == True
 
+- name: edit xdebug.idekey value
+  lineinfile:
+    path: /etc/opt/remi/php73/php.d/15-xdebug.ini
+    regexp: '^;xdebug\.idekey = \*complex\*'
+    line: 'xdebug.idekey = {{ xdebug_ide_key }}'
+    state: present
+  when:
+    - xdebug|d(False) == True
+    - xdebug_ide_key is defined
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-73/templates/xdebug.ini
+++ b/ansible/roles/php-73/templates/xdebug.ini
@@ -728,7 +728,7 @@ xdebug.remote_host = 10.0.2.2
 ;     -> <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/db ... ></response>
 ;
 ;
-xdebug.remote_log ="/tmp/xdebug.log"
+;xdebug.remote_log ="/tmp/xdebug.log"
 
 ; -----------------------------------------------------------------------------
 ; xdebug.remote_mode

--- a/ansible/roles/php-73/templates/xdebug.ini
+++ b/ansible/roles/php-73/templates/xdebug.ini
@@ -1,0 +1,1024 @@
+; Enable xdebug extension module
+zend_extension=xdebug.so
+
+; Configuration
+; See https://xdebug.org/docs/all_settings
+
+
+; -----------------------------------------------------------------------------
+; xdebug.auto_trace
+;
+; Type: boolean, Default value: 0
+;
+; When this setting is set to on, the tracing of function calls will be enabled
+; just before the script is run. This makes it possible to trace code in the
+; auto_prepend_file [1].
+;
+; [1] http://php.net/manual/en/ini.core.php#ini.auto-prepend-file
+;
+;
+;xdebug.auto_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.cli_color
+;
+; Only in Xdebug versions > 2.2
+;
+; Type: integer, Default value: 0
+;
+; If this setting is 1, Xdebug will color var_dumps and stack traces output when
+; in CLI mode and when the output is a tty. On Windows, the ANSICON [1] tool
+; needs to be installed.
+;
+; [1] http://adoxa.110mb.com/ansicon/
+;
+; If the setting is 2, then Xdebug will always color var_dumps and stack trace,
+; no matter whether it's connected to a tty or whether ANSICON is installed. In
+; this case, you might end up seeing escape codes.
+;
+; See this article [1] for some more information.
+;
+; [1] https://drck.me/clicolor-9cr
+;
+;
+;xdebug.cli_color = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_assignments
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should add variable
+; assignments to function traces.
+;
+;
+;xdebug.collect_assignments = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_includes
+;
+; Type: boolean, Default value: 1
+;
+; This setting, defaulting to 1, controls whether Xdebug should write the
+; filename used in include(), include_once(), require() or require_once() to the
+; trace files.
+;
+;
+;xdebug.collect_includes = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_params
+;
+; Type: integer, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should collect the
+; parameters passed to functions when a function call is recorded in either the
+; function trace or the stack trace.
+;
+; The setting defaults to 0 because for very large scripts it may use huge
+; amounts of memory and therefore make it impossible for the huge script to run.
+; You can most safely turn this setting on, but you can expect some problems in
+; scripts with a lot of function calls and/or huge data structures as
+; parameters. Xdebug 2 will not have this problem with increased memory usage,
+; as it will never store this information in memory. Instead it will only be
+; written to disk. This means that you need to have a look at the disk usage
+; though.
+;
+; This setting can have four different values. For each of the values a
+; different amount of information is shown. Below you will see what information
+; each of the values provides. See also the introduction of the feature Stack
+; Traces for a few screenshots.
+;
+; =====  ========================================================================
+; Value  Argument Information Shown
+; =====  ========================================================================
+; 0      None.
+; -----  ------------------------------------------------------------------------
+; 1      Type and number of elements (f.e. string(6), array(8)).
+; -----  ------------------------------------------------------------------------
+; 2      Type and number of elements, with a tool tip for the full information 1.
+; -----  ------------------------------------------------------------------------
+; 3      Full variable contents (with the limits respected as set by
+;        xdebug.var_display_max_children, xdebug.var_display_max_data and
+;        xdebug.var_display_max_depth.
+; -----  ------------------------------------------------------------------------
+; 4      Full variable contents and variable name.
+; -----  ------------------------------------------------------------------------
+; 5      PHP serialized variable contents, without the name.
+;
+;        (New in Xdebug 2.3)
+; =====  ========================================================================
+;
+; 1 in the CLI version of PHP it will not have the tool tip, nor in output
+; files.
+;
+;
+;xdebug.collect_params = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_return
+;
+; Type: boolean, Default value: 0
+;
+; This setting, defaulting to 0, controls whether Xdebug should write the return
+; value of function calls to the trace files.
+;
+; For computerized trace files (xdebug.trace_format=1) this only works from
+; Xdebug 2.3 onwards.
+;
+;
+;xdebug.collect_return = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.collect_vars
+;
+; Type: boolean, Default value: 0
+;
+; This setting tells Xdebug to gather information about which variables are used
+; in a certain scope. This analysis can be quite slow as Xdebug has to reverse
+; engineer PHP's opcode arrays. This setting will not record which values the
+; different variables have, for that use xdebug.collect_params. This setting
+; needs to be enabled only if you wish to use xdebug_get_declared_vars().
+;
+;
+;xdebug.collect_vars = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.coverage_enable
+;
+; Only in Xdebug versions >= 2.2
+;
+; Type: boolean, Default value: 1
+;
+; If this setting is set to 0, then Xdebug will not set-up internal structures
+; to allow code coverage. This speeds up Xdebug quite a bit, but of course, Code
+; Coverage Analysis won't work.
+;
+;
+;xdebug.coverage_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.default_enable
+;
+; Type: boolean, Default value: 1
+;
+; If this setting is 1, then stacktraces will be shown by default on an error
+; event. You can disable showing stacktraces from your code with
+; xdebug_disable(). As this is one of the basic functions of Xdebug, it is
+; advisable to leave this setting set to 1.
+;
+;
+;xdebug.default_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump.*
+;
+; Type: string, Default value: Empty
+;
+; * can be any of COOKIE, FILES, GET, POST, REQUEST, SERVER, SESSION. These
+; seven settings control which data from the superglobals is shown when an error
+; situation occurs.
+;
+; Each of those php.ini setting can consist of a comma seperated list of
+; variables from this superglobal to dump, or ``*`` for all of them. Make sure
+; you do not add spaces in this setting.
+;
+; In order to dump the REMOTE_ADDR and the REQUEST_METHOD when an error occurs,
+; and all GET parameters, add these settings:
+;
+;     xdebug.dump.SERVER = REMOTE_ADDR,REQUEST_METHOD
+;     xdebug.dump.GET = *
+;
+;
+;xdebug.dump.* = Empty
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_globals
+;
+; Type: boolean, Default value: 1
+;
+; Controls whether the values of the superglobals as defined by the
+; xdebug.dump.* settings should be shown or not.
+;
+;
+;xdebug.dump_globals = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_once
+;
+; Type: boolean, Default value: 1
+;
+; Controls whether the values of the superglobals should be dumped on all error
+; situations (set to 0) or only on the first (set to 1).
+;
+;
+;xdebug.dump_once = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.dump_undefined
+;
+; Type: boolean, Default value: 0
+;
+; If you want to dump undefined values from the superglobals you should set this
+; setting to 1, otherwise leave it set to 0.
+;
+;
+;xdebug.dump_undefined = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.extended_info
+;
+; Type: integer, Default value: 1
+;
+; Controls whether Xdebug should enforce 'extended_info' mode for the PHP
+; parser; this allows Xdebug to do file/line breakpoints with the remote
+; debugger. When tracing or profiling scripts you generally want to turn off
+; this option as PHP's generated oparrays will increase with about a third of
+; the size slowing down your scripts. This setting can not be set in your
+; scripts with ini_set(), but only in php.ini.
+;
+;
+;xdebug.extended_info = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.file_link_format
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: string, Default value:
+;
+; This setting determines the format of the links that are made in the display
+; of stack traces where file names are used. This allows IDEs to set up a
+; link-protocol that makes it possible to go directly to a line and file by
+; clicking on the filenames that Xdebug shows in stack traces. An example format
+; might look like:
+;
+;     myide://%f@%l
+;
+; The possible format specifiers are:
+;
+; =========  ===============
+; Specifier  Meaning
+; =========  ===============
+; %f         the filename
+; ---------  ---------------
+; %l         the line number
+; =========  ===============
+;
+; For various IDEs/OSses there are some instructions listed on how to make this
+; work:
+;
+; ----------------
+; Firefox on Linux
+; ----------------
+;
+; - Open
+;
+;   about:config
+;
+; - Add a new boolean setting "network.protocol-handler.expose.xdebug" and set
+;   it to "false"
+;
+; - Add the following into a shell script
+;
+;   ``~/bin/ff-xdebug.sh``:
+;
+;     #! /bin/sh
+;
+;     f=`echo $1 | cut -d @ -f 1 | sed 's/xdebug:\/\///'`
+;     l=`echo $1 | cut -d @ -f 2`
+;
+;   Add to that one of (depending whether you have komodo, gvim or netbeans):
+;
+;   - komodo $f -l $l
+;
+;   - gvim --remote-tab +$l $f
+;
+;   - netbeans "$f:$l"
+;
+; - Make the script executable with
+;
+; chmod +x ~/bin/ff-xdebug.sh
+;
+; - Set the xdebug.file_link_format setting to
+;
+; xdebug://%f@%l
+;
+; --------------------
+; Windows and netbeans
+; --------------------
+;
+; - Create the file
+;
+;   ``netbeans.bat`` and save it in your path ( ``C:\Windows`` will work):
+;
+;     @echo off
+;     setlocal enableextensions enabledelayedexpansion
+;     set NETBEANS=%1
+;     set FILE=%~2
+;     %NETBEANS% --nosplash --console suppress --open "%FILE:~19%"
+;     nircmd win activate process netbeans.exe
+;
+;   **Note:** Remove the last line if you don't have ``nircmd``.
+;
+; - Save the following code as
+;
+;   ``netbeans_protocol.reg``:
+;
+;     Windows Registry Editor Version 5.00
+;
+;     [HKEY_CLASSES_ROOT\netbeans]
+;     "URL Protocol"=""
+;     @="URL:Netbeans Protocol"
+;
+;     [HKEY_CLASSES_ROOT\netbeans\DefaultIcon]
+;     @="\"C:\\Program Files\\NetBeans 7.1.1\\bin\\netbeans.exe,1\""
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell]
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell\open]
+;
+;     [HKEY_CLASSES_ROOT\netbeans\shell\open\command]
+;     @="\"C:\\Windows\\netbeans.bat\" \"C:\\Program Files\\NetBeans 7.1.1\\bin\\netbeans.exe\" \"%1\""
+;
+;   **Note:** Make sure to change the path to Netbeans (twice), as well as the
+;   ``netbeans.bat`` batch file if you saved it somewhere else than
+;   ``C:\Windows\``.
+;
+; - Double click on the
+;
+;   ``netbeans_protocol.reg`` file to import it into the registry.
+;
+; - Set the xdebug.file_link_format setting to
+;
+; xdebug.file_link_format =
+;     "netbeans://open/?f=%f:%l"
+;
+;
+;xdebug.file_link_format =
+
+; -----------------------------------------------------------------------------
+; xdebug.force_display_errors
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; If this setting is set to ``1`` then errors will **always** be displayed, no
+; matter what the setting of PHP's display_errors [1] is.
+;
+; [1] http://php.net/manual/en/errorfunc.configuration.php#ini.display-errors
+;
+;
+;xdebug.force_display_errors = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.force_error_reporting
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; This setting is a bitmask, like error_reporting [1]. This bitmask will be
+; logically ORed with the bitmask represented by error_reporting [2] to dermine
+; which errors should be displayed. This setting can only be made in php.ini and
+; allows you to force certain errors from being shown no matter what an
+; application does with ini_set() [3].
+;
+; [1] http://php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+; [2] http://php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+; [3] http://php.net/manual/en/function.ini-set.php
+;
+;
+;xdebug.force_error_reporting = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.halt_level
+;
+; Only in Xdebug versions 2.3
+;
+; Type: int, Default value: 0
+;
+; This setting allows you to configure a mask that determines whether, and
+; which, notices and/or warnings get converted to errors. You can configure
+; notices and warnings that are generated by PHP, and notices and warnings that
+; you generate yourself (by means of trigger_error()). For example, to convert
+; the warning of strlen() (without arguments) to an error, you would do:
+;
+;     ini_set('xdebug.halt_level', E_WARNING);
+;     strlen();
+;     echo "Hi!\n";
+;
+; Which will then result in the showing of the error message, and the abortion
+; of the script. ``echo "Hi!\n";`` will not be executed.
+;
+; The setting is a bit mask, so to convert all notices and warnings into errors
+; for all applications, you can set this in php.ini:
+;
+;     xdebug.halt_level=E_WARNING|E_NOTICE|E_USER_WARNING|E_USER_NOTICE
+;
+; The bitmask only supports the four level that are mentioned above.
+;
+;
+;xdebug.halt_level = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.idekey
+;
+; Type: string, Default value: *complex*
+;
+; Controls which IDE Key Xdebug should pass on to the DBGp debugger handler. The
+; default is based on environment settings. First the environment setting
+; DBGP_IDEKEY is consulted, then USER and as last USERNAME. The default is set
+; to the first environment variable that is found. If none could be found the
+; setting has as default ''. If this setting is set, it always overrides the
+; environment variables.
+;
+;
+;xdebug.idekey = *complex*
+
+; -----------------------------------------------------------------------------
+; xdebug.manual_url
+;
+; Only in Xdebug versions < 2.2.1
+;
+; Type: string, Default value: http://www.php.net
+;
+; This is the base url for the links from the function traces and error message
+; to the manual pages of the function from the message. It is advisable to set
+; this setting to use the closest mirror.
+;
+;
+;xdebug.manual_url = http://www.php.net
+
+; -----------------------------------------------------------------------------
+; xdebug.max_nesting_level
+;
+; Type: integer, Default value: 256
+;
+; Controls the protection mechanism for infinite recursion protection. The value
+; of this setting is the maximum level of nested functions that are allowed
+; before the script will be aborted.
+;
+; Before Xdebug 2.3, the default value was ``100``.
+;
+;
+;xdebug.max_nesting_level = 256
+
+; -----------------------------------------------------------------------------
+; xdebug.max_stack_frames
+;
+; Only in Xdebug versions >= 2.3
+;
+; Type: integer, Default value: -1
+;
+; Controls how many stack frames are shown in stack traces, both on the command
+; line during PHP error stack traces, as well as in the browser for HTML traces.
+;
+;
+;xdebug.max_stack_frames = -1
+
+; -----------------------------------------------------------------------------
+; xdebug.overload_var_dump
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 2
+;
+; By default Xdebug overloads var_dump() with its own improved version for
+; displaying variables when the html_errors php.ini setting is set to ``1`` or
+; ``2``. In case you do not want that, you can set this setting to ``0``, but
+; check first if it's not smarter to turn off html_errors.
+;
+; You can also use ``2`` as value for this setting. Besides formatting the
+; var_dump() output nicely, it will also add filename and line number to the
+; output. The xdebug.file_link_format setting is also respected. *(New in Xdebug
+; 2.3)*
+;
+; Before Xdebug 2.4, the default value of this setting was ``1``.
+;
+;
+;xdebug.overload_var_dump = 2
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_aggregate
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, a single profiler file will be written for
+; multiple requests. One can surf to multiple pages or reload a page to get an
+; **average** across all requests. The file will be named
+; ``.cachegrind.aggregate``. You will need to move this file to get another
+; round of aggregate data.
+;
+;
+;xdebug.profiler_aggregate = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_append
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, profiler files will not be overwritten when a
+; new request would map to the same file (depending on the
+; xdebug.profiler_output_name setting. Instead the file will be appended to with
+; the new profile.
+;
+;
+;xdebug.profiler_append = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable
+;
+; Type: integer, Default value: 0
+;
+; Enables Xdebug's profiler which creates files in the profile output directory.
+; Those files can be read by KCacheGrind to visualize your data. This setting
+; can not be set in your script with ini_set(). If you want to selectively
+; enable the profiler, please set xdebug.profiler_enable_trigger to 1
+; **instead** of using this setting.
+;
+;
+;xdebug.profiler_enable = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable_trigger
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, you can trigger the generation of profiler
+; files by using the XDEBUG_PROFILE GET/POST parameter, or set a cookie with the
+; name XDEBUG_PROFILE. This will then write the profiler data to defined
+; directory. In order to prevent the profiler to generate profile files for each
+; request, you need to set xdebug.profiler_enable to 0. Access to the trigger
+; itself can be configured through xdebug.profiler_enable_trigger_value.
+;
+;
+;xdebug.profiler_enable_trigger = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_enable_trigger_value
+;
+; Only in Xdebug versions > 2.3
+;
+; Type: string, Default value: ""
+;
+; This setting can be used to restrict who can make use of the XDEBUG_PROFILE
+; functionality as outlined in xdebug.profiler_enable_trigger. When changed from
+; its default value of an empty string, the value of the cookie, GET or POST
+; argument needs to match the shared secret set with this setting in order for
+; the profiler to start.
+;
+;
+;xdebug.profiler_enable_trigger_value = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_output_dir
+;
+; Type: string, Default value: /tmp
+;
+; The directory where the profiler output will be written to, make sure that the
+; user who the PHP will be running as has write permissions to that directory.
+; This setting can not be set in your script with ini_set().
+;
+;
+;xdebug.profiler_output_dir = /tmp
+
+; -----------------------------------------------------------------------------
+; xdebug.profiler_output_name
+;
+; Type: string, Default value: cachegrind.out.%p
+;
+; This setting determines the name of the file that is used to dump traces into.
+; The setting specifies the format with format specifiers, very similar to
+; sprintf() and strftime(). There are several format specifiers that can be used
+; to format the file name.
+;
+; See the xdebug.trace_output_name documentation for the supported specifiers.
+;
+;
+;xdebug.profiler_output_name = cachegrind.out.%p
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_addr_header
+;
+; Only in Xdebug versions > 2.4
+;
+; Type: string, Default value: ""
+;
+; If xdebug.remote_addr_header is configured to be a non-empty string, then the
+; value is used as key in the $SERVER superglobal array to determine which
+; header to use to find the IP address or hostname to use for 'connecting back
+; to'. This setting is only used in combination with xdebug.remote_connect_back
+; and is otherwise ignored.
+;
+;
+;xdebug.remote_addr_header = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_autostart
+;
+; Type: boolean, Default value: 0
+;
+; Normally you need to use a specific HTTP GET/POST variable to start remote
+; debugging (see Remote Debugging). When this setting is set to 1, Xdebug will
+; always attempt to start a remote debugging session and try to connect to a
+; client, even if the GET/POST/COOKIE variable was not present.
+;
+;
+;xdebug.remote_autostart = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_connect_back
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: boolean, Default value: 0
+;
+; If enabled, the xdebug.remote_host setting is ignored and Xdebug will try to
+; connect to the client that made the HTTP request. It checks the
+; $_SERVER['HTTP_X_FORWARDED_FOR'] and $_SERVER['REMOTE_ADDR'] variables to find
+; out which IP address to use.
+;
+; If xdebug.remote_addr_header is configured, then the $SERVER variable with the
+; configured name will be checked before the $_SERVER['HTTP_X_FORWARDED_FOR']
+; and $_SERVER['REMOTE_ADDR'] variables.
+;
+; This setting does not apply for debugging through the CLI, as the $SERVER
+; header variables are not available there.
+;
+; Please note that there is **no** filter available, and anybody who can connect
+; to the webserver will then be able to start a debugging session, even if their
+; address does not match xdebug.remote_host.
+;
+;
+xdebug.remote_connect_back = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_cookie_expire_time
+;
+; Only in Xdebug versions > 2.1
+;
+; Type: integer, Default value: 3600
+;
+; This setting can be used to increase (or decrease) the time that the remote
+; debugging session stays alive via the session cookie.
+;
+;
+;xdebug.remote_cookie_expire_time = 3600
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_enable
+;
+; Type: boolean, Default value: 0
+;
+; This switch controls whether Xdebug should try to contact a debug client which
+; is listening on the host and port as set with the settings xdebug.remote_host
+; and xdebug.remote_port. If a connection can not be established the script will
+; just continue as if this setting was 0.
+;
+;
+xdebug.remote_enable = 1
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_handler
+;
+; Type: string, Default value: dbgp
+;
+; Can be either 'php3' which selects the old PHP 3 style debugger [1] output,
+; 'gdb' which enables the GDB like debugger interface or 'dbgp' - the debugger
+; protocol [2]. The DBGp protocol is the only supported protocol.
+;
+; [1] http://www.php.net/manual/en/debugger.php
+; [2] https://xdebug.org/docs-dbgp.php
+;
+; **Note**: Xdebug 2.1 and later only support 'dbgp' as protocol.
+;
+;
+;xdebug.remote_handler = dbgp
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_host
+;
+; Type: string, Default value: localhost
+;
+; Selects the host where the debug client is running, you can either use a host
+; name or an IP address. This setting is ignored if xdebug.remote_connect_back
+; is enabled.
+;
+;
+xdebug.remote_host = 10.0.2.2
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_log
+;
+; Type: string, Default value:
+;
+; If set to a value, it is used as filename to a file to which all remote
+; debugger communications are logged. The file is always opened in append-mode,
+; and will therefore not be overwritten by default. There is no concurrency
+; protection available. The format of the file looks something like:
+;
+;     Log opened at 2007-05-27 14:28:15
+;     -> <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/x ... ight></init>
+;
+;     <- step_into -i 1
+;     -> <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/db ... ></response>
+;
+;
+xdebug.remote_log ="/tmp/xdebug.log"
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_mode
+;
+; Type: string, Default value: req
+;
+; Selects when a debug connection is initiated. This setting can have two
+; different values:
+;
+; req
+;     Xdebug will try to connect to the debug client as soon as the script
+;     starts.
+;
+; jit
+;     Xdebug will only try to connect to the debug client as soon as an error
+;     condition occurs.
+;
+;
+xdebug.remote_mode = req
+
+; -----------------------------------------------------------------------------
+; xdebug.remote_port
+;
+; Type: integer, Default value: 9000
+;
+; The port to which Xdebug tries to connect on the remote host. Port 9000 is the
+; default for both the client and the bundled debugclient. As many clients use
+; this port number, it is best to leave this setting unchanged.
+;
+;
+xdebug.remote_port = 9001
+
+; -----------------------------------------------------------------------------
+; xdebug.scream
+;
+; Only in Xdebug versions >= 2.1
+;
+; Type: boolean, Default value: 0
+;
+; If this setting is 1, then Xdebug will disable the @ (shut-up) operator so
+; that notices, warnings and errors are no longer hidden.
+;
+;
+;xdebug.scream = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_error_trace
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, Xdebug will show a stack trace whenever an
+; Error is raised - even if this Error is actually caught.
+;
+;
+;xdebug.show_error_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_exception_trace
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to 1, Xdebug will show a stack trace whenever an
+; Exception or Error is raised - even if this Exception or Error is actually
+; caught.
+;
+; Error 'exceptions' were introduced in PHP 7.
+;
+;
+;xdebug.show_exception_trace = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_local_vars
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to something != 0 Xdebug's generated stack dumps in
+; error situations will also show all variables in the top-most scope. Beware
+; that this might generate a lot of information, and is therefore turned off by
+; default.
+;
+;
+;xdebug.show_local_vars = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.show_mem_delta
+;
+; Type: integer, Default value: 0
+;
+; When this setting is set to something != 0 Xdebug's human-readable generated
+; trace files will show the difference in memory usage between function calls.
+; If Xdebug is configured to generate computer-readable trace files then they
+; will always show this information.
+;
+;
+;xdebug.show_mem_delta = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_enable_trigger
+;
+; Only in Xdebug versions > 2.2
+;
+; Type: boolean, Default value: 0
+;
+; When this setting is set to 1, you can trigger the generation of trace files
+; by using the XDEBUG_TRACE GET/POST parameter, or set a cookie with the name
+; XDEBUG_TRACE. This will then write the trace data to defined directory. In
+; order to prevent Xdebug to generate trace files for each request, you need to
+; set xdebug.auto_trace to 0. Access to the trigger itself can be configured
+; through xdebug.trace_enable_trigger_value.
+;
+;
+;xdebug.trace_enable_trigger = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_enable_trigger_value
+;
+; Only in Xdebug versions > 2.3
+;
+; Type: string, Default value: ""
+;
+; This setting can be used to restrict who can make use of the XDEBUG_TRACE
+; functionality as outlined in xdebug.trace_enable_trigger. When changed from
+; its default value of an empty string, the value of the cookie, GET or POST
+; argument needs to match the shared secret set with this setting in order for
+; the trace file to be generated.
+;
+;
+;xdebug.trace_enable_trigger_value = ""
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_format
+;
+; Type: integer, Default value: 0
+;
+; The format of the trace file.
+;
+; =====  ==============================================================================
+; Value  Description
+; =====  ==============================================================================
+; 0      shows a human readable indented trace file with:
+;
+;        *time index*, *memory usage*, *memory delta* (if the setting
+;        xdebug.show_mem_delta is enabled), *level*, *function name*, *function
+;        parameters* (if the setting xdebug.collect_params is enabled), *filename* and
+;        *line number*.
+; -----  ------------------------------------------------------------------------------
+; 1      writes a computer readable format which has two different records. There are
+;        different records for entering a stack frame, and leaving a stack frame. The
+;        table below lists the fields in each type of record. Fields are tab separated.
+; -----  ------------------------------------------------------------------------------
+; 2      writes a trace formatted in (simple) HTML.
+; =====  ==============================================================================
+;
+; Fields for the computerized format:
+;
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+; Record type  1      2            3            4           5             6              7                                            8                                 9         10           11                 12 - ...
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+; Entry        level  function #  always '0'  time index  memory usage  function name  user-defined (1) or internal function (0)  name of the include/require file  filename  line number  no. of parameters  parameters (as many as specified in field 11) - tab separated
+; -----------  -----  -----------  -----------  ----------  ------------  -------------  -------------------------------------------  --------------------------------  --------  -----------  -----------------  -------------------------------------------------------------
+; Exit         level  function #  always '1'  time index  memory usage  empty
+; -----------  -----  -----------  -----------  ----------  ------------  -------------  -------------------------------------------  --------------------------------  --------  -----------  -----------------  -------------------------------------------------------------
+; Return       level  function #  always 'R'  empty       return value  empty
+; ===========  =====  ===========  ===========  ==========  ============  =============  ===========================================  ================================  ========  ===========  =================  =============================================================
+;
+; See the introduction of Function Traces for a few examples.
+;
+;
+;xdebug.trace_format = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_options
+;
+; Type: integer, Default value: 0
+;
+; When set to '1' the trace files will be appended to, instead of being
+; overwritten in subsequent requests.
+;
+;
+;xdebug.trace_options = 0
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_output_dir
+;
+; Type: string, Default value: /tmp
+;
+; The directory where the tracing files will be written to, make sure that the
+; user who the PHP will be running as has write permissions to that directory.
+;
+;
+;xdebug.trace_output_dir = /tmp
+
+; -----------------------------------------------------------------------------
+; xdebug.trace_output_name
+;
+; Type: string, Default value: trace.%c
+;
+; This setting determines the name of the file that is used to dump traces into.
+; The setting specifies the format with format specifiers, very similar to
+; sprintf() and strftime(). There are several format specifiers that can be used
+; to format the file name. The '.xt' extension is always added automatically.
+;
+; The possible format specifiers are:
+;
+; =========  ======================================  =================  ====================================================
+; Specifier  Meaning                                 Example Format     Example Filename
+; =========  ======================================  =================  ====================================================
+; %c         crc32 of the current working directory  trace.%c           trace.1258863198.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %p         pid                                     trace.%p           trace.5174.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %r         random number                           trace.%r           trace.072db0.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %s         script name 2                           cachegrind.out.%s  cachegrind.out._home_httpd_html_test_xdebug_test_php
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %t         timestamp (seconds)                     trace.%t           trace.1179434742.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %u         timestamp (microseconds)                trace.%u           trace.1179434749_642382.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %H         $_SERVER['HTTP_HOST']                   trace.%H           trace.kossu.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %R         $_SERVER['REQUEST_URI']                 trace.%R           trace._test_xdebug_test_php_var=1_var2=2.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %U         $_SERVER['UNIQUE_ID']                   trace.%U           trace.TRX4n38AAAEAAB9gBFkAAAAB.xt
+;
+;            3
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %S         session_id (from $_COOKIE if set)       trace.%S           trace.c70c1ec2375af58f74b390bbdd2a679d.xt
+; ---------  --------------------------------------  -----------------  ----------------------------------------------------
+; %%         literal %                               trace.%%           trace.%%.xt
+; =========  ======================================  =================  ====================================================
+;
+; 2 This one is not available for trace file names.
+;
+; 3 New in version 2.2. This one is set by Apache's mod_unique_id module [1]
+;
+; [1] http://httpd.apache.org/docs/2.2/en/mod/mod_unique_id.html
+;
+;
+;xdebug.trace_output_name = trace.%c
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_children
+;
+; Type: integer, Default value: 128
+;
+; Controls the amount of array children and object's properties are shown when
+; variables are displayed with either xdebug_var_dump(), xdebug.show_local_vars
+; or through Function Traces.
+;
+; To disable any limitation, use *-1* as value.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_children = 128
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_data
+;
+; Type: integer, Default value: 512
+;
+; Controls the maximum string length that is shown when variables are displayed
+; with either xdebug_var_dump(), xdebug.show_local_vars or through Function
+; Traces.
+;
+; To disable any limitation, use *-1* as value.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_data = 512
+
+; -----------------------------------------------------------------------------
+; xdebug.var_display_max_depth
+;
+; Type: integer, Default value: 3
+;
+; Controls how many nested levels of array elements and object properties are
+; when variables are displayed with either xdebug_var_dump(),
+; xdebug.show_local_vars or through Function Traces.
+;
+; The maximum value you can select is 1023. You can also use *-1* as value to
+; select this maximum number.
+;
+; This setting does not have any influence on the number of children that is
+; send to the client through the Remote Debugging feature.
+;
+;
+;xdebug.var_display_max_depth = 3
+

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -23,3 +23,37 @@
     insertafter: 'EOF'
   with_items: "{{ bash | default([]) }}"
   changed_when: false
+
+- name: add file relating to xdebug environment variables setting
+  become: true
+  become_user: vagrant
+  template:
+    src: xdebug_start_vars
+    dest: ~/.xdebug_start_vars
+  when: xdebug|d(False) == True
+  changed_when: false
+
+- name: add file relating to xdebug environment variables unsetting
+  become: true
+  become_user: vagrant
+  template:
+    src: xdebug_stop_vars
+    dest: ~/.xdebug_stop_vars
+  when: xdebug|d(False) == True
+  changed_when: false
+
+- name: insert aliase to use xdebug on cli scripts easily
+  become: true
+  become_user: vagrant
+  blockinfile:
+    path: ~/.bashrc
+    block: |
+      alias xdebugstart="source ~/.xdebug_start_vars"
+      alias xdebugstop="source ~/.xdebug_stop_vars"
+    insertafter: 'EOF'
+  when: xdebug|d(False) == True
+  changed_when: false
+
+- name: validate ~/.bashrc after changes
+  command: bash -n ~/.bashrc
+  changed_when: false

--- a/ansible/roles/shell/templates/xdebug_start_vars
+++ b/ansible/roles/shell/templates/xdebug_start_vars
@@ -1,0 +1,1 @@
+export XDEBUG_CONFIG="idekey={{ xdebug_ide_key|d("PHPSTORM") }}"

--- a/ansible/roles/shell/templates/xdebug_stop_vars
+++ b/ansible/roles/shell/templates/xdebug_stop_vars
@@ -1,0 +1,1 @@
+unset XDEBUG_CONFIG


### PR DESCRIPTION
Adding to the ansible commands and variables to make it easier to provision the box with Xdebug ready to use from browser or from command line.
Two new settings in group_vars/all
- xdebug (bool)
- xdebug_ide_key (string referring to your ide)
When xdebug set to true then xdebug.ini file copied to appropriate place for enabled php version. Settings allow for remote enabling from specified host (10.0.2.2 - vagrant host) on port 9001.
Also write some new aliases into .bashrc for easy setting and unsetting of environment variables to allow xdebugging of command line scripts. See xdebugstart and xdebugstop.