### PR TITLE
Add prompt only to mysql settings

### DIFF
--- a/ansible/roles/mysql-57/templates/my-root.cnf.j2
+++ b/ansible/roles/mysql-57/templates/my-root.cnf.j2
@@ -1,4 +1,6 @@
 [client]
 user={{ mysql_root_db_user }}
 password='{{ mysql_root_db_pass }}'
+
+[mysql]
 prompt='(\u@\h) [\d]> '


### PR DESCRIPTION
This is so you can test mysqldump and mysqlpump on local dev machines. As they do not currently parse the prompt setting.