### PR TITLE
Increase group_concat_max_len from default to 16kb

### DIFF
--- a/ansible/roles/mysql-57/tasks/main.yml
+++ b/ansible/roles/mysql-57/tasks/main.yml
@@ -28,6 +28,13 @@
   with_items: "{{ client | default([]) }}"
   changed_when: false
 
+- name: Overwrite default group concat max length
+  lineinfile:
+    path: /etc/my.cnf
+    line: 'group_concat_max_len=15360'
+    insertafter: 'sql_mode=NO_ENGINE_SUBSTITUTION'
+  changed_when: false
+
 - name: Start the MySQL service
   service:
     name: mysqld


### PR DESCRIPTION
This is to solve an issue where group_concat_max_len defaults to 1kb causing unexpected errors on large queries. This fix is to increase that setting to 16kb.